### PR TITLE
feat(ci): add opencode workflow timeout, concurrency, and permissions

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -17,6 +17,10 @@ jobs:
       ) &&
       contains(fromJson('["OWNER","MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+    concurrency:
+      group: opencode-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       id-token: write
       contents: write

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "/home/runner/**": "allow"
+    }
+  }
+}

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "setup": "bun i"
+  }
+}


### PR DESCRIPTION
## Summary
- Add 120-minute timeout and concurrency group with cancel-in-progress to opencode CI workflow
- Add `opencode.json` with external directory permission for `/home/runner/**`
- Add `paseo.json` with worktree setup config to run `bun i`

## Testing
- Verify `.github/workflows/opencode.yml` contains `timeout-minutes: 120` and concurrency configuration
- Verify `opencode.json` grants `allow` permission to `/home/runner/**`
- Verify `paseo.json` specifies `bun i` as the worktree setup command
- Not run