### PR TITLE
feat(sidebar): port Paseo's status-bucket directory and view menu

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,10 +14,11 @@ A running (or finished) Paseo agent working in a workspace directory. One agent
 owns one conversation timeline.
 
 **Agent directory**:
-The list of known agents, kept fresh by subscription updates, grouped by
-status bucket in the sidebar (Needs input, Failed, Ready to review, Working,
-Done — mirroring Paseo's own groups). Archived agents stay hidden behind a
-sidebar toggle and read dimmed when revealed; archiving is one-way.
+The list of known agents, kept fresh by subscription updates, arranged in the
+sidebar by status bucket (Needs input, Failed, Ready to review, Working,
+Done) or by project, chosen in the sidebar's view menu. Archived agents stay
+hidden behind the view menu's Show section and read dimmed when revealed;
+archiving is one-way.
 _Avoid_: session list, conversation list
 
 **Timeline item**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,7 +15,9 @@ owns one conversation timeline.
 
 **Agent directory**:
 The list of known agents, kept fresh by subscription updates, grouped by
-recency in the sidebar.
+status bucket in the sidebar (Needs input, Failed, Ready to review, Working,
+Done — mirroring Paseo's own groups). Archived agents stay hidden behind a
+sidebar toggle and read dimmed when revealed; archiving is one-way.
 _Avoid_: session list, conversation list
 
 **Timeline item**:

--- a/assets/icons/archive.svg
+++ b/assets/icons/archive.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>

--- a/chat.tsx
+++ b/chat.tsx
@@ -23,13 +23,14 @@ import {
   displayName,
   errorMessage,
   findModel,
+  isArchived,
   sortAgents,
   type AgentEntry,
   type ConnStatus,
   type ProviderEntry,
 } from './paseo'
 import { C, CONTENT_MAX_WIDTH, SIDEBAR_WIDTH } from './theme'
-import { Sidebar, Header, CenterMessage, agentStatusColor, daemonHost } from './chrome'
+import { Sidebar, Header, CenterMessage, agentStatusColor, daemonHost, type RowActionRef, type RowActionVerb } from './chrome'
 import { Transcript } from './transcript'
 import { ModelPicker, OptionPicker, modeOptions, thinkingOptions } from './pickers'
 import { Composer, ConfigNotice, FooterBar } from './composer'
@@ -70,8 +71,10 @@ function useDaemon(): DaemonView {
       unsubs.push(
         client.agents.subscribe((update) => setAgents((prev) => applyAgentUpdate(prev, update))),
       )
+      // Archived entries ride along so the sidebar toggle can reveal them;
+      // visibility is decided at render time.
       const sort = [{ key: 'updated_at' as const, direction: 'desc' as const }]
-      const filter = { includeArchived: false }
+      const filter = { includeArchived: true }
       await client.agents.list({ scope: 'active', filter, sort, subscribe: {} })
       const page = await client.agents.list({ scope: 'active', filter, sort })
       if (!disposed) setAgents(sortAgents(page.entries.map((entry) => entry.agent)))
@@ -143,6 +146,35 @@ export function ChatApp() {
   const turns = conversation.turns
   const permissions = useAgentPermissions(client, daemon, activeId)
   const activeEntry = agents.find((entry) => entry.id === activeId) ?? null
+
+  // An agent that vanished from the directory (deleted) or was archived can no
+  // longer host a conversation — Paseo's own client redirects away in both cases.
+  const activeEntryGone =
+    activeId != null &&
+    status === 'connected' &&
+    agents.length > 0 &&
+    !agents.some((entry) => entry.id === activeId && !isArchived(entry))
+  useEffect(() => {
+    if (activeEntryGone) setActiveId(null)
+  }, [activeEntryGone])
+
+  // Row lifecycle actions disable per row while their daemon call is in flight;
+  // directory truth arrives through the subscription, never from these results.
+  const [busyRows, setBusyRows] = useState<RowActionRef[]>([])
+  const runRowAction = async (verb: RowActionVerb, id: string, action: () => Promise<unknown>) => {
+    setBusyRows((prev) => [...prev, { verb, id }])
+    try {
+      await action()
+    } catch (err) {
+      setCreateError(errorMessage(err))
+    } finally {
+      setBusyRows((prev) => prev.filter((row) => row.verb !== verb || row.id !== id))
+    }
+  }
+  const archiveAgentRow = (id: string) => runRowAction('archive', id, () => daemon.archiveAgent(id))
+  const deleteAgentRow = (id: string) => runRowAction('delete', id, () => daemon.deleteAgent(id))
+  const renameAgentRow = (id: string, name: string) =>
+    runRowAction('rename', id, () => daemon.updateAgent(id, { name }))
 
   // Chip values for an active agent come from the live agent; the draft stays
   // authoritative only while no agent is selected.
@@ -305,6 +337,10 @@ export function ChatApp() {
           onNewTask={() => setActiveId(null)}
           onCollapse={() => setCollapsed(true)}
           status={status}
+          busyRows={busyRows}
+          onArchive={archiveAgentRow}
+          onDelete={deleteAgentRow}
+          onRename={renameAgentRow}
         />
         <div style={{ width: 1, height: '100%', flexShrink: 0, backgroundColor: C.sidebarBorder }} />
       </motion.div>

--- a/chrome.tsx
+++ b/chrome.tsx
@@ -13,10 +13,12 @@ import {
   basename,
   displayName,
   isArchived,
+  projectGroups,
   relativeTime,
   statusGroups,
   type AgentEntry,
   type ConnStatus,
+  type DirectoryGroupMode,
 } from './paseo'
 import { C, SIDEBAR_WIDTH, TITLEBAR_HEIGHT, TRAFFIC_LIGHT_CLEARANCE } from './theme'
 
@@ -45,6 +47,7 @@ import iconZap from './assets/icons/zap.svg' with { type: 'file' }
 import iconPencil from './assets/icons/pencil.svg' with { type: 'file' }
 import iconChevronDown from './assets/icons/chevron-down.svg' with { type: 'file' }
 import iconEllipsis from './assets/icons/ellipsis.svg' with { type: 'file' }
+import iconArchive from './assets/icons/archive.svg' with { type: 'file' }
 import iconListFilter from './assets/icons/list-filter.svg' with { type: 'file' }
 import iconSparkle from './assets/icons/sparkle.svg' with { type: 'file' }
 import iconWrench from './assets/icons/wrench.svg' with { type: 'file' }
@@ -68,6 +71,7 @@ const ICONS = {
   pencil: realAssetPath(iconPencil),
   chevronDown: realAssetPath(iconChevronDown),
   ellipsis: realAssetPath(iconEllipsis),
+  archive: realAssetPath(iconArchive),
   listFilter: realAssetPath(iconListFilter),
   sparkle: realAssetPath(iconSparkle),
   wrench: realAssetPath(iconWrench),
@@ -196,6 +200,126 @@ export type RowActionVerb = 'rename' | 'archive' | 'delete'
 export interface RowActionRef {
   verb: RowActionVerb
   id: string
+}
+
+const VIEW_MENU_WIDTH = 232
+
+/**
+ * One decision row of the view menu: leading icon, label, and the engine's own
+ * check when this is the current answer.
+ */
+function ViewOption({
+  icon,
+  label,
+  selected,
+}: {
+  icon: IconName
+  label: string
+  selected: boolean
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        width: '100%',
+        paddingTop: 5,
+        paddingBottom: 5,
+        paddingLeft: 8,
+        paddingRight: 8,
+        borderRadius: 7,
+        hover: { backgroundColor: '#404040' },
+      }}
+    >
+      <Icon name={icon} size={13} color={C.tertiary} />
+      <text style={{ fontSize: 12.5, fontWeight: 500, color: C.text, flexGrow: 1, minWidth: 0 }}>
+        {label}
+      </text>
+      {selected && <Icon name="check" size={11} color={C.secondary} />}
+    </div>
+  )
+}
+
+function ViewSection({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        height: 22,
+        paddingLeft: 8,
+      }}
+    >
+      <text style={{ fontSize: 11.5, fontWeight: 500, color: C.ghost }}>{label}</text>
+    </div>
+  )
+}
+
+function ViewSeparator() {
+  return <div style={{ height: 1, backgroundColor: C.border, marginTop: 4, marginBottom: 4 }} />
+}
+
+/**
+ * The sidebar's display-preferences popover, mirroring Paseo's: one trigger in
+ * the section header, grouping as a radio choice, visibility toggles under
+ * Show. Decisions that would be dead controls here (title source, trailing
+ * diff stat, host/project/label filters) have no backing data on this client
+ * and stay out.
+ */
+function ViewPreferencesMenu({
+  groupMode,
+  onGroupModeChange,
+  showArchived,
+  onShowArchivedChange,
+}: {
+  groupMode: DirectoryGroupMode
+  onGroupModeChange: (mode: DirectoryGroupMode) => void
+  showArchived: boolean
+  onShowArchivedChange: (show: boolean) => void
+}) {
+  const runChoice = (choice: string) => {
+    if (choice.startsWith('grouping:')) onGroupModeChange(choice.slice('grouping:'.length) as DirectoryGroupMode)
+    else if (choice === 'show:archived') onShowArchivedChange(!showArchived)
+  }
+
+  return (
+    <Select value="" onValueChange={runChoice}>
+      <SelectTrigger
+        testId="sidebar-view-menu"
+        style={(state) => ({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 26,
+          height: 26,
+          flexShrink: 0,
+          borderRadius: 6,
+          cursor: 'pointer',
+          backgroundColor: state.open ? C.overlay : '#00000000',
+          hover: { backgroundColor: C.overlay },
+        })}
+      >
+        <Icon name="listFilter" size={14} color={C.secondary} />
+      </SelectTrigger>
+      <SelectContent side="bottom" align="end" sideOffset={4} style={{ width: VIEW_MENU_WIDTH }}>
+        <ViewSection label="Grouping" />
+        <SelectItem value="grouping:project" textValue="Project">
+          <ViewOption icon="folder" label="Project" selected={groupMode === 'project'} />
+        </SelectItem>
+        <SelectItem value="grouping:status" textValue="Status">
+          <ViewOption icon="list" label="Status" selected={groupMode === 'status'} />
+        </SelectItem>
+        <ViewSeparator />
+        <ViewSection label="Show" />
+        <SelectItem value="show:archived" textValue="Archived agents">
+          <ViewOption icon="archive" label="Archived agents" selected={showArchived} />
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  )
 }
 
 function AgentRow({
@@ -417,7 +541,11 @@ export function Sidebar({
   onRename: (id: string, name: string) => void
 }) {
   const [showArchived, setShowArchived] = useState(false)
-  const groups = useMemo(() => statusGroups(agents, showArchived), [agents, showArchived])
+  const [groupMode, setGroupMode] = useState<DirectoryGroupMode>('status')
+  const groups = useMemo(
+    () => (groupMode === 'project' ? projectGroups(agents, showArchived) : statusGroups(agents, showArchived)),
+    [agents, showArchived, groupMode],
+  )
 
   return (
     <div
@@ -475,11 +603,11 @@ export function Sidebar({
         <text style={{ fontSize: 13, fontWeight: 500, color: C.secondary, flexGrow: 1, minWidth: 0 }}>
           Agents
         </text>
-        <IconButton
-          icon="listFilter"
-          testId="sidebar-archived-toggle"
-          dimmed={!showArchived}
-          onClick={() => setShowArchived((prev) => !prev)}
+        <ViewPreferencesMenu
+          groupMode={groupMode}
+          onGroupModeChange={setGroupMode}
+          showArchived={showArchived}
+          onShowArchivedChange={setShowArchived}
         />
       </div>
 

--- a/chrome.tsx
+++ b/chrome.tsx
@@ -6,8 +6,18 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import React, { useMemo } from 'react'
-import { DAEMON_URL, basename, displayName, groupLabel, relativeTime, sortAgents, type AgentEntry, type ConnStatus } from './paseo'
+import React, { useMemo, useState } from 'react'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@gpuix/react'
+import {
+  DAEMON_URL,
+  basename,
+  displayName,
+  isArchived,
+  relativeTime,
+  statusGroups,
+  type AgentEntry,
+  type ConnStatus,
+} from './paseo'
 import { C, SIDEBAR_WIDTH, TITLEBAR_HEIGHT, TRAFFIC_LIGHT_CLEARANCE } from './theme'
 
 function realAssetPath(virtualPath: string): string {
@@ -34,6 +44,7 @@ import iconList from './assets/icons/list.svg' with { type: 'file' }
 import iconZap from './assets/icons/zap.svg' with { type: 'file' }
 import iconPencil from './assets/icons/pencil.svg' with { type: 'file' }
 import iconChevronDown from './assets/icons/chevron-down.svg' with { type: 'file' }
+import iconEllipsis from './assets/icons/ellipsis.svg' with { type: 'file' }
 import iconListFilter from './assets/icons/list-filter.svg' with { type: 'file' }
 import iconSparkle from './assets/icons/sparkle.svg' with { type: 'file' }
 import iconWrench from './assets/icons/wrench.svg' with { type: 'file' }
@@ -56,6 +67,7 @@ const ICONS = {
   zap: realAssetPath(iconZap),
   pencil: realAssetPath(iconPencil),
   chevronDown: realAssetPath(iconChevronDown),
+  ellipsis: realAssetPath(iconEllipsis),
   listFilter: realAssetPath(iconListFilter),
   sparkle: realAssetPath(iconSparkle),
   wrench: realAssetPath(iconWrench),
@@ -178,52 +190,161 @@ function SidebarAction({
   )
 }
 
+export type RowActionVerb = 'rename' | 'archive' | 'delete'
+
+/** One row lifecycle call in flight; every action on that row stays disabled until it settles. */
+export interface RowActionRef {
+  verb: RowActionVerb
+  id: string
+}
+
 function AgentRow({
   entry,
   active,
+  busy,
   onSelect,
+  onRename,
+  onArchive,
+  onDelete,
 }: {
   entry: AgentEntry
   active: boolean
+  /** True while any lifecycle action on this row is in flight. */
+  busy: boolean
   onSelect: (id: string) => void
+  onRename: (id: string, name: string) => void
+  onArchive: (id: string) => void
+  onDelete: (id: string) => void
 }) {
+  const [hover, setHover] = useState(false)
+  const [renaming, setRenaming] = useState(false)
+  const [nameDraft, setNameDraft] = useState('')
+  const archived = isArchived(entry)
+
+  const startRename = () => {
+    setNameDraft(displayName(entry))
+    setRenaming(true)
+  }
+
+  /**
+   * Empty or unchanged drafts cancel; anything else goes to the daemon. Runs at
+   * most once per edit — blur after commit or cancel is ignored.
+   */
+  const commitRename = () => {
+    if (!renaming) return
+    setRenaming(false)
+    const next = nameDraft.trim()
+    if (busy || next.length === 0 || next === displayName(entry)) return
+    onRename(entry.id, next)
+  }
+
+  const runAction = (action: RowActionVerb) => {
+    if (busy) return
+    if (action === 'rename') startRename()
+    else if (action === 'archive') onArchive(entry.id)
+    else onDelete(entry.id)
+  }
+
   return (
     <div
+      testId="agent-row"
       style={{
         display: 'flex',
         flexDirection: 'column',
-        gap: 4,
+        gap: 3,
         paddingLeft: 8,
-        paddingRight: 8,
+        paddingRight: 4,
         paddingTop: 7,
         paddingBottom: 7,
         borderRadius: 7,
-        cursor: 'pointer',
+        cursor: renaming ? 'default' : 'pointer',
         backgroundColor: active ? C.item : '#00000000',
-        hover: { backgroundColor: C.item },
+        hover: renaming ? undefined : { backgroundColor: C.item },
+        opacity: archived ? 0.55 : 1,
       }}
-      onClick={() => onSelect(entry.id)}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onClick={() => {
+        if (!renaming) onSelect(entry.id)
+      }}
     >
-      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-        <text
+      {renaming ? (
+        <input
+          value={nameDraft}
+          placeholder="Agent name"
+          autoFocus
+          testId="agent-rename"
           style={{
-            fontSize: 13.5,
-            lineHeight: 18,
-            color: C.text,
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-            minWidth: 0,
             flexGrow: 1,
+            minWidth: 0,
+            height: 20,
+            fontSize: 13.5,
+            color: C.text,
+            backgroundColor: '#00000000',
+            borderWidth: 0,
+            padding: 0,
           }}
-        >
-          {displayName(entry)}
-        </text>
-        {(entry.status === 'running' || entry.requiresAttention || entry.status === 'error') && (
+          onChange={(event) => setNameDraft(event.value ?? '')}
+          onSubmit={commitRename}
+          onBlur={commitRename}
+          onKeyDown={(event) => {
+            if (event.key === 'escape') setRenaming(false)
+          }}
+        />
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 6 }}>
           <StatusDot color={agentStatusColor(entry)} />
-        )}
-        <text style={{ fontSize: 12.5, color: C.ghost, flexShrink: 0 }}>{relativeTime(entry)}</text>
-      </div>
-      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+          <text
+            style={{
+              fontSize: 13.5,
+              lineHeight: 18,
+              color: C.text,
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+              minWidth: 0,
+              flexGrow: 1,
+            }}
+          >
+            {displayName(entry)}
+          </text>
+          {hover ? (
+            <Select value="" onValueChange={(action) => runAction(action as RowActionVerb)}>
+              <SelectTrigger
+                testId="agent-row-menu"
+                style={(state) => ({
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 20,
+                  height: 20,
+                  flexShrink: 0,
+                  borderRadius: 5,
+                  cursor: 'pointer',
+                  backgroundColor: state.open ? C.overlayStrong : '#00000000',
+                })}
+              >
+                <Icon name="ellipsis" size={14} color={C.secondary} />
+              </SelectTrigger>
+              <SelectContent side="right" sideOffset={2} style={{ minWidth: 168 }}>
+                <SelectItem value="rename" textValue="Rename">
+                  <MenuAction label="Rename" disabled={busy} />
+                </SelectItem>
+                {!archived && (
+                  <SelectItem value="archive" textValue="Archive">
+                    <MenuAction label="Archive" disabled={busy} />
+                  </SelectItem>
+                )}
+                <SelectItem value="delete" textValue="Delete">
+                  <MenuAction label="Delete" tone="danger" disabled={busy} />
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          ) : (
+            <text style={{ fontSize: 12.5, color: C.ghost, flexShrink: 0 }}>{relativeTime(entry)}</text>
+          )}
+        </div>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 5, paddingLeft: 13 }}>
         <Icon name="folder" size={12.5} color={C.tertiary} />
         <text
           style={{
@@ -246,6 +367,31 @@ function AgentRow({
   )
 }
 
+/** One row-action menu entry; danger rows carry their own tone. */
+function MenuAction({ label, tone, disabled }: { label: string; tone?: 'danger'; disabled?: boolean }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        width: '100%',
+        paddingTop: 5,
+        paddingBottom: 5,
+        paddingLeft: 8,
+        paddingRight: 8,
+        borderRadius: 7,
+        opacity: disabled ? 0.4 : 1,
+        hover: disabled ? undefined : { backgroundColor: '#404040' },
+      }}
+    >
+      <text style={{ fontSize: 12.5, fontWeight: 500, color: tone === 'danger' ? C.danger : C.text }}>
+        {label}
+      </text>
+    </div>
+  )
+}
+
 export function Sidebar({
   agents,
   activeId,
@@ -253,6 +399,10 @@ export function Sidebar({
   onNewTask,
   onCollapse,
   status,
+  busyRows,
+  onArchive,
+  onDelete,
+  onRename,
 }: {
   agents: AgentEntry[]
   activeId: string | null
@@ -260,17 +410,14 @@ export function Sidebar({
   onNewTask: () => void
   onCollapse: () => void
   status: ConnStatus
+  /** Row lifecycle calls currently in flight. */
+  busyRows: RowActionRef[]
+  onArchive: (id: string) => void
+  onDelete: (id: string) => void
+  onRename: (id: string, name: string) => void
 }) {
-  const groups = useMemo(() => {
-    const out: { name: string; items: AgentEntry[] }[] = []
-    for (const entry of sortAgents(agents)) {
-      const name = groupLabel(entry)
-      const last = out[out.length - 1]
-      if (last && last.name === name) last.items.push(entry)
-      else out.push({ name, items: [entry] })
-    }
-    return out
-  }, [agents])
+  const [showArchived, setShowArchived] = useState(false)
+  const groups = useMemo(() => statusGroups(agents, showArchived), [agents, showArchived])
 
   return (
     <div
@@ -316,6 +463,29 @@ export function Sidebar({
       <div
         style={{
           display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          height: 30,
+          flexShrink: 0,
+          paddingLeft: 18,
+          paddingRight: 12,
+          marginTop: 6,
+        }}
+      >
+        <text style={{ fontSize: 13, fontWeight: 500, color: C.secondary, flexGrow: 1, minWidth: 0 }}>
+          Agents
+        </text>
+        <IconButton
+          icon="listFilter"
+          testId="sidebar-archived-toggle"
+          dimmed={!showArchived}
+          onClick={() => setShowArchived((prev) => !prev)}
+        />
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
           flexDirection: 'column',
           flexGrow: 1,
           minHeight: 0,
@@ -324,7 +494,7 @@ export function Sidebar({
           paddingRight: 10,
         }}
       >
-        {groups.map((group, groupIndex) => (
+        {groups.map((group) => (
           <div
             key={group.name}
             style={{ display: 'flex', flexDirection: 'column', paddingBottom: 10 }}
@@ -334,30 +504,25 @@ export function Sidebar({
                 display: 'flex',
                 flexDirection: 'row',
                 alignItems: 'center',
-                height: 28,
+                height: 26,
                 paddingLeft: 8,
                 paddingRight: 8,
               }}
             >
-              <text
-                style={{
-                  fontSize: 13,
-                  fontWeight: 500,
-                  color: C.secondary,
-                  flexGrow: 1,
-                  minWidth: 0,
-                }}
-              >
+              <text style={{ fontSize: 12.5, color: C.tertiary, flexGrow: 1, minWidth: 0 }}>
                 {group.name}
               </text>
-              {groupIndex === 0 && <Icon name="listFilter" size={14} color={C.secondary} />}
             </div>
             {group.items.map((entry) => (
               <AgentRow
                 key={entry.id}
                 entry={entry}
                 active={entry.id === activeId}
+                busy={busyRows.some((row) => row.id === entry.id)}
                 onSelect={onSelect}
+                onRename={onRename}
+                onArchive={onArchive}
+                onDelete={onDelete}
               />
             ))}
           </div>

--- a/paseo.test.ts
+++ b/paseo.test.ts
@@ -8,6 +8,7 @@ import {
   relativeTime,
   statusBucket,
   statusGroups,
+  projectGroups,
   visibleAgents,
   STATUS_BUCKET_LABELS,
   defaultModelValue,
@@ -543,6 +544,39 @@ describe('statusGroups', () => {
     ]
     const groups = statusGroups(entries, false)
     expect(groups[0]!.items.map((e) => e.id)).toEqual(['new', 'old'])
+  })
+})
+
+describe('projectGroups', () => {
+  test('groups by directory basename, most recently active project first', () => {
+    const entries = [
+      entry({ id: 'store-1', cwd: '/home/me/dev/storefront', updatedAt: '2026-08-24T11:00:00Z' }),
+      entry({ id: 'api-1', cwd: '/home/me/dev/api', updatedAt: '2026-08-24T11:30:00Z' }),
+      entry({ id: 'store-2', cwd: '/other/place/storefront', updatedAt: '2026-08-24T10:00:00Z' }),
+    ]
+    const groups = projectGroups(entries, false)
+    expect(groups.map((group) => group.name)).toEqual(['api', 'storefront'])
+    expect(groups[1]!.items.map((e) => e.id)).toEqual(['store-1', 'store-2'])
+  })
+
+  test('archived entries trail in their own group only when revealed', () => {
+    const entries = [
+      entry({ id: 'live', cwd: '/home/me/dev/storefront' }),
+      entry({ id: 'gone', cwd: '/home/me/dev/api', archivedAt: '2026-08-24T09:00:00Z' }),
+    ]
+    expect(projectGroups(entries, false).map((group) => group.name)).toEqual(['storefront'])
+    const revealed = projectGroups(entries, true)
+    expect(revealed.map((group) => group.name)).toEqual(['storefront', 'Archived'])
+    expect(revealed[1]!.items.map((e) => e.id)).toEqual(['gone'])
+  })
+
+  test('status and project grouping agree on what is visible', () => {
+    const entries = [
+      entry({ id: 'live' }),
+      entry({ id: 'gone', archivedAt: '2026-08-24T09:00:00Z' }),
+    ]
+    const flat = (groups: { items: AgentEntry[] }[]) => groups.flatMap((group) => group.items.map((e) => e.id))
+    expect(flat(statusGroups(entries, true))).toEqual(flat(projectGroups(entries, true)))
   })
 })
 

--- a/paseo.test.ts
+++ b/paseo.test.ts
@@ -5,8 +5,11 @@ import {
   applyAgentUpdate,
   sortAgents,
   displayName,
-  groupLabel,
   relativeTime,
+  statusBucket,
+  statusGroups,
+  visibleAgents,
+  STATUS_BUCKET_LABELS,
   defaultModelValue,
   modelChoices,
   findModel,
@@ -449,9 +452,97 @@ describe('agent directory', () => {
     expect(removed).toHaveLength(2)
   })
 
-  test('groupLabel and relativeTime produce known shapes', () => {
-    expect(['Today', 'Yesterday', 'Previous 7 Days', 'Earlier']).toContain(groupLabel(list[0]!))
+  test('relativeTime produces known shapes', () => {
     expect(relativeTime(list[0]!)).toMatch(/^now|\d+[mhd]|\w{3} \d{1,2}$/)
+  })
+})
+
+describe('status buckets', () => {
+  test('labels mirror Paseo\'s sidebar groups', () => {
+    expect(STATUS_BUCKET_LABELS).toEqual({
+      needs_input: 'Needs input',
+      failed: 'Failed',
+      review: 'Ready to review',
+      working: 'Working',
+      done: 'Done',
+    })
+  })
+
+  test('permission attention buckets as needs input', () => {
+    const e = entry({ status: 'running', requiresAttention: true, attentionReason: 'permission' })
+    expect(statusBucket(e)).toBe('needs_input')
+  })
+
+  test('finished attention is ready to review', () => {
+    const e = entry({ status: 'idle', requiresAttention: true, attentionReason: 'finished' })
+    expect(statusBucket(e)).toBe('review')
+  })
+
+  test('error status buckets as failed even with unrelated attention', () => {
+    expect(statusBucket(entry({ status: 'error' }))).toBe('failed')
+  })
+
+  test('running and initializing bucket as working', () => {
+    expect(statusBucket(entry({ status: 'running' }))).toBe('working')
+    expect(statusBucket(entry({ status: 'initializing' }))).toBe('working')
+  })
+
+  test('idle and closed fall through to done', () => {
+    expect(statusBucket(entry({ status: 'idle' }))).toBe('done')
+    expect(statusBucket(entry({ status: 'closed' }))).toBe('done')
+  })
+})
+
+describe('statusGroups', () => {
+  test('groups follow Paseo\'s bucket order, dropping empty ones', () => {
+    const entries = [
+      entry({ id: 'idle-1', updatedAt: '2026-08-24T11:00:00Z' }),
+      entry({ id: 'err-1', status: 'error', updatedAt: '2026-08-24T11:01:00Z' }),
+      entry({ id: 'run-1', status: 'running', updatedAt: '2026-08-24T11:02:00Z' }),
+      entry({
+        id: 'perm-1',
+        status: 'running',
+        requiresAttention: true,
+        attentionReason: 'permission',
+        updatedAt: '2026-08-24T11:03:00Z',
+      }),
+    ]
+    const groups = statusGroups(entries, false)
+    expect(groups.map((group) => group.name)).toEqual(['Needs input', 'Failed', 'Working', 'Done'])
+    expect(groups[0]!.items.map((e) => e.id)).toEqual(['perm-1'])
+    expect(groups[3]!.items.map((e) => e.id)).toEqual(['idle-1'])
+  })
+
+  test('review sits between failed and working', () => {
+    const entries = [
+      entry({ id: 'rev-1', requiresAttention: true, attentionReason: 'finished' }),
+      entry({ id: 'done-1' }),
+    ]
+    const groups = statusGroups(entries, false)
+    expect(groups.map((group) => group.name)).toEqual(['Ready to review', 'Done'])
+  })
+
+  test('archived entries stay hidden until revealed, then trail in their own group', () => {
+    const entries = [
+      entry({ id: 'live', updatedAt: '2026-08-24T11:00:00Z' }),
+      entry({ id: 'gone', archivedAt: '2026-08-24T09:00:00Z' }),
+    ]
+    expect(visibleAgents(entries, false).map((e) => e.id)).toEqual(['live'])
+    expect(statusGroups(entries, false)).toHaveLength(1)
+
+    expect(visibleAgents(entries, true).map((e) => e.id)).toEqual(['live', 'gone'])
+    const groups = statusGroups(entries, true)
+    expect(groups.map((group) => group.name)).toEqual(['Done', 'Archived'])
+    expect(groups[1]!.items.map((e) => e.id)).toEqual(['gone'])
+  })
+
+  test('revealing archived keeps live groups sorted by recency within each bucket', () => {
+    const entries = [
+      entry({ id: 'old', updatedAt: '2026-08-24T10:00:00Z' }),
+      entry({ id: 'new', updatedAt: '2026-08-24T12:00:00Z' }),
+    ]
+    const groups = statusGroups(entries, false)
+    expect(groups[0]!.items.map((e) => e.id)).toEqual(['new', 'old'])
   })
 })
 

--- a/paseo.ts
+++ b/paseo.ts
@@ -500,22 +500,64 @@ export function displayName(entry: AgentEntry): string {
   return basename(entry.cwd)
 }
 
+// ---- sidebar status groups --------------------------------------------------
+//
+// The directory groups by state bucket rather than date, mirroring Paseo's own
+// sidebar (packages/app, STATUS_BUCKET_ORDER): trouble first, then attention,
+// then live work, then finished.
+
+export type StatusBucket = 'needs_input' | 'failed' | 'review' | 'working' | 'done'
+
+export const STATUS_BUCKETS: readonly StatusBucket[] = ['needs_input', 'failed', 'review', 'working', 'done']
+
+export const STATUS_BUCKET_LABELS: Record<StatusBucket, string> = {
+  needs_input: 'Needs input',
+  failed: 'Failed',
+  review: 'Ready to review',
+  working: 'Working',
+  done: 'Done',
+}
+
+/** Maps an agent's snapshot to its directory bucket. Attention outranks status. */
+export function statusBucket(entry: AgentEntry): StatusBucket {
+  if (entry.requiresAttention && entry.attentionReason === 'permission') return 'needs_input'
+  if (entry.status === 'error') return 'failed'
+  if (entry.requiresAttention && entry.attentionReason === 'finished') return 'review'
+  if (entry.status === 'running' || entry.status === 'initializing') return 'working'
+  return 'done'
+}
+
+/** True once the daemon has archived the agent; archiving is one-way. */
+export function isArchived(entry: AgentEntry): boolean {
+  return entry.archivedAt != null
+}
+
+/** Live agents only unless archived ones are revealed. */
+export function visibleAgents(entries: AgentEntry[], showArchived: boolean): AgentEntry[] {
+  return showArchived ? entries : entries.filter((entry) => !isArchived(entry))
+}
+
+/**
+ * Folds the directory into labeled groups for the sidebar: non-empty status
+ * buckets in Paseo's order, each recency-sorted, plus a trailing Archived
+ * group when one is revealed.
+ */
+export function statusGroups(
+  entries: AgentEntry[],
+  showArchived: boolean,
+): { name: string; items: AgentEntry[] }[] {
+  const sorted = sortAgents(visibleAgents(entries, showArchived))
+  const groups: { name: string; items: AgentEntry[] }[] = []
+  for (const bucket of STATUS_BUCKETS) {
+    const items = sorted.filter((entry) => !isArchived(entry) && statusBucket(entry) === bucket)
+    if (items.length > 0) groups.push({ name: STATUS_BUCKET_LABELS[bucket], items })
+  }
+  const archived = showArchived ? sorted.filter(isArchived) : []
+  if (archived.length > 0) groups.push({ name: 'Archived', items: archived })
+  return groups
+}
+
 const DAY_MS = 86_400_000
-
-function startOfDay(ms: number): number {
-  const date = new Date(ms)
-  date.setHours(0, 0, 0, 0)
-  return date.getTime()
-}
-
-export function groupLabel(entry: AgentEntry): string {
-  const day = startOfDay(activityAt(entry))
-  const today = startOfDay(Date.now())
-  if (day === today) return 'Today'
-  if (day === today - DAY_MS) return 'Yesterday'
-  if (day > today - 7 * DAY_MS) return 'Previous 7 Days'
-  return 'Earlier'
-}
 
 export function relativeTime(entry: AgentEntry): string {
   const delta = Math.max(0, Date.now() - activityAt(entry))

--- a/paseo.ts
+++ b/paseo.ts
@@ -537,6 +537,17 @@ export function visibleAgents(entries: AgentEntry[], showArchived: boolean): Age
   return showArchived ? entries : entries.filter((entry) => !isArchived(entry))
 }
 
+/** Appends the trailing Archived group when one is revealed; both group modes share it. */
+function withArchivedTail(
+  groups: { name: string; items: AgentEntry[] }[],
+  sorted: AgentEntry[],
+  showArchived: boolean,
+): { name: string; items: AgentEntry[] }[] {
+  const archived = showArchived ? sorted.filter(isArchived) : []
+  if (archived.length > 0) groups.push({ name: 'Archived', items: archived })
+  return groups
+}
+
 /**
  * Folds the directory into labeled groups for the sidebar: non-empty status
  * buckets in Paseo's order, each recency-sorted, plus a trailing Archived
@@ -552,9 +563,30 @@ export function statusGroups(
     const items = sorted.filter((entry) => !isArchived(entry) && statusBucket(entry) === bucket)
     if (items.length > 0) groups.push({ name: STATUS_BUCKET_LABELS[bucket], items })
   }
-  const archived = showArchived ? sorted.filter(isArchived) : []
-  if (archived.length > 0) groups.push({ name: 'Archived', items: archived })
-  return groups
+  return withArchivedTail(groups, sorted, showArchived)
+}
+
+/** How the sidebar arranges the directory, chosen in its view menu. */
+export type DirectoryGroupMode = 'status' | 'project'
+
+/**
+ * Folds the directory into per-project groups named by working directory,
+ * most recently active project first, plus the shared Archived tail.
+ */
+export function projectGroups(
+  entries: AgentEntry[],
+  showArchived: boolean,
+): { name: string; items: AgentEntry[] }[] {
+  const sorted = sortAgents(visibleAgents(entries, showArchived))
+  const groups: { name: string; items: AgentEntry[] }[] = []
+  for (const entry of sorted) {
+    if (isArchived(entry)) continue
+    const name = basename(entry.cwd)
+    const last = groups[groups.length - 1]
+    if (last && last.name === name) last.items.push(entry)
+    else groups.push({ name, items: [entry] })
+  }
+  return withArchivedTail(groups, sorted, showArchived)
 }
 
 const DAY_MS = 86_400_000


### PR DESCRIPTION
## Summary

Ports Paseo's own sidebar directory model to the GPU client.

- **Status-bucket directory** — sidebar rows grouped into Paseo's buckets (Needs input / Failed / Ready to review / Working / Done), attention outranking status, recency-sorted within bucket, plus a trailing Archived group (`paseo.ts` statusGroups/statusBucket).
- **Row lifecycle** — rename/archive/delete through the daemon driver with per-row in-flight disabling; directory truth arrives only via subscription.
- **View menu** — display-preferences popover with Grouping (Project | Status) radio and Show → Archived agents toggle.

Tests: `bun test` — 92 pass.

## Attribution

Implemented by the **ox-alpha** model via the **opencode** agent harness.
