### PR TITLE
ci: stop bot comments from cancelling in-flight review runs

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,8 +1,14 @@
 name: opencode-review
 
-# Automatic: every pull_request event (except bot-actor synchronizations).
+# Automatic: every pull_request event (except bot actors).
 # Manual: comment "/review" on a PR. Extra text after "/review" is passed to
 # the reviewer as notes; the review methodology itself stays fixed here.
+#
+# Bot-authored comments never trigger anything here. Their comments re-enter
+# this workflow (the reviewer posts its verdict as a comment), so the job
+# gate must reject them AND concurrency must live at job level: a workflow-
+# level group engages even when every job skips, so a bot verdict comment
+# used to cancel the very review run that posted it.
 
 on:
   pull_request:
@@ -10,20 +16,20 @@ on:
   issue_comment:
     types: [created]
 
-concurrency:
-  group: opencode-review-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   review:
     if: |
-      (github.event_name == 'pull_request' && github.actor != 'opencode-agent[bot]') ||
+      (github.event_name == 'pull_request' && !endsWith(github.actor, '[bot]')) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
+        !endsWith(github.event.comment.user.login, '[bot]') &&
         startsWith(github.event.comment.body, '/review') &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
+    concurrency:
+      group: opencode-review-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -15,6 +15,7 @@ jobs:
         contains(github.event.comment.body, ' /opencode') ||
         startsWith(github.event.comment.body, '/opencode')
       ) &&
+      !endsWith(github.event.comment.user.login, '[bot]') &&
       contains(fromJson('["OWNER","MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 120


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Root cause (observed in the 04:58Z wave)

Each reviewer finishes by posting its verdict as an **issue comment**. That comment re-triggers `opencode-review`. The new run joined the same workflow-level concurrency group `opencode-review-<n>`, and `cancel-in-progress` killed the parent run — *after* it had posted. Result: 12 of 16 reviews show conclusion=`cancelled`; on #93 the formal review submission was lost to the race (summary comment landed, `pulls.createReview` never did). Same latent path exists for any bot push/comment while a review is in flight.

Job-level `if` guards do not help: concurrency engages at **run** level before job conditions are evaluated.

## Fix

1. **Move `concurrency:` into the `review` job** (mirrors `opencode.yml`). Skipped runs no longer engage the group; human re-reviews still cancel in-flight ones, as designed.
2. **Explicit bot-author gates** in both workflows (`!endsWith(...login, '[bot]')`), and review workflow's PR-actor check generalized from `!= 'opencode-agent[bot]'` to any `[bot]` actor. Bot output can no longer start either workflow at all — belt and braces on top of the association checks.

## Behavior after merge

| Trigger | Before | After |
|---|---|---|
| Reviewer posts verdict comment | new skipped run cancels parent | nothing starts |
| Bot pushes commits mid-review | PR-event run could cancel review | nothing starts |
| Human posts second `/review` while one runs | cancels previous | cancels previous (unchanged) |
| Human syncs a PR branch mid-review | auto-review joins group, may cancel | unchanged |

Verified: YAML parses; diff is 13 lines across two files. Part 1 of 2 — the follow-up PR adds `/review` incremental + `/full-review` whole-PR scoping.