### PR TITLE
chore(ci): allow agent access to /tmp on runners

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -2,7 +2,8 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": {
     "external_directory": {
-      "/home/runner/**": "allow"
+      "/home/runner/**": "allow",
+      "/tmp/**": "allow"
     }
   }
 }


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Problem

The opencode agent in GitHub Actions resolves external-directory reads (`/tmp`, `/etc`, …) to the interactive `ask` permission. Headless runners can never answer `ask`, so the run hangs until the 120-minute job timeout kills it — zero output, zero verdict. Observed live three times: the #97 fix-agent dead run (hung on `/etc/*` for 1h55m) and two cancelled review runs today that requested `/tmp` access.

## Fix

Whitelist `/tmp/**` in `opencode.json` alongside the existing `/home/runner/**` allow, so agents can read/write temp space without tripping the permission prompt.

## Notes for reviewers

- This config is loaded from the default branch for comment-triggered runs, so it must land on `main` before any re-dispatch is useful.
- Known remaining gap: unlisted paths still fall back to `ask`; converting the fallback to `deny` would fail fast instead of hanging, but that also changes behavior for local interactive sessions, so it is deliberately left out of this PR.