### PR TITLE
fix: unblock app boot

### DIFF
--- a/chat.tsx
+++ b/chat.tsx
@@ -57,6 +57,9 @@ import {
   type IncomingImage,
   type PastePayload,
 } from './attachments'
+import { C, CONTENT_MAX_WIDTH, SIDEBAR_WIDTH } from './theme'
+import { Sidebar, Header, CenterMessage, agentStatusColor, daemonHost, type RowActionRef, type RowActionVerb } from './chrome'
+import { Transcript } from './transcript'
 import { FeatureToggles, ModelPicker, OptionPicker, modeOptions, thinkingOptions } from './pickers'
 import { Composer, ConfigNotice, FooterBar, TracksRow } from './composer'
 import { useAgentConversation } from './conversation'
@@ -385,13 +388,6 @@ export function ChatApp() {
   useEffect(() => {
     setViewing(null)
   }, [activeId])
-  useEffect(() => {
-    // A provider subagent's timeline is garbage-collected the moment its
-    // descriptor leaves the directory; a viewer still pointed at it would sit
-    // on "Loading subagent…" forever. The row no longer being in the track
-    // proves it's gone, so fold the viewer back.
-    if (viewing?.kind === 'provider' && !viewingRow) setViewing(null)
-  }, [viewing, viewingRow])
   const subagentRows = useMemo(
     () => selectTrackRows(subagents.state, agents, activeId, subagents.enabled),
     [subagents.state, subagents.enabled, agents, activeId],
@@ -399,6 +395,13 @@ export function ChatApp() {
   const viewingRow = viewing
     ? subagentRows.find((row) => row.kind === viewing.kind && row.id === viewing.id) ?? null
     : null
+  useEffect(() => {
+    // A provider subagent's timeline is garbage-collected the moment its
+    // descriptor leaves the directory; a viewer still pointed at it would sit
+    // on "Loading subagent…" forever. The row no longer being in the track
+    // proves it's gone, so fold the viewer back.
+    if (viewing?.kind === 'provider' && !viewingRow) setViewing(null)
+  }, [viewing, viewingRow])
   const viewingSubagent = viewing?.kind === 'provider' ? viewing : null
   const providerTurns =
     viewingSubagent
@@ -889,7 +892,7 @@ const listRef = useRef<{ id: number } | null>(null)
         }}
       >
         <Sidebar
-          store={workspaces}
+          workspaces={workspaces}
           activeWorkspaceId={selectedWorkspaceId}
           onSelect={openWorkspace}
           onNewTask={() => {

--- a/transcript.tsx
+++ b/transcript.tsx
@@ -3,7 +3,7 @@
  * pending permission cards appended after the conversation.
  */
 
-import React, { memo, useCallback, useMemo, useRef, useState } from 'react'
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useGpuix } from '@gpuix/react'
 import type { EventPayload } from '@gpuix/native'
 import { Icon, IconButton, StatusDot, type IconName } from './chrome'


### PR DESCRIPTION
Found while preparing the repo-layout move: **main has been unable to boot since ~Aug 25** — `bun chat.tsx` crashed on first render. Three independent causes, all fixed here:

1. **Merge-dropped imports.** The merge resolution around f185ddd dropped three import lines from `chat.tsx` (`./theme`, `./chrome`, `./transcript`) and `useEffect` from `transcript.tsx`'s React import. First render threw on unbound identifiers (`C`, `Sidebar`, `Header`, `Transcript`, `daemonHost`, `agentStatusColor`, …). Proven via `git show e0b93fd:chat.tsx` (imports present) and bundle analysis (`jsxDEV(Transcript, …)` with no definition in the bundle).
2. **TDZ in ChatApp.** The subagent fold-back effect read `viewingRow` in its dependency array before the `const` was declared → `ReferenceError: Cannot access 'viewingRow' before initialization` at chat.tsx:397. The effect now sits below the declaration; order among effects is unchanged.
3. **Sidebar prop name mismatch.** `chat.tsx` passed `store={workspaces}` while the `Sidebar` interface names the prop `workspaces` → `TypeError: undefined is not an object (evaluating 'store.workspaces')`. The call site now uses the interface's name.

## Verification

- `bun test`: 541 pass / 0 fail (unchanged baseline)
- tsc audit (ad-hoc CLI flags, no repo config added): zero remaining unbound identifiers; error count 276 → 249, remainder pre-existing (test-global noise, duplicate `AgentUsage` in paseo.ts, type mismatches — candidate #3 territory)
- `bun build chat.tsx`: resolves, Transcript now bundled
- `bun chat.tsx`: native window created, `mount complete`, runs clean (no errors, stays alive)

Nothing here changes behavior; it restores what a merge resolution dropped and fixes two latent ordering/naming bugs it unmasked. The stacked layout move (`chore/repo-layout`) builds on this branch.