### PR TITLE
Spec: Workspace layer: sidebar polish, tabs, panes (#33)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -159,6 +159,15 @@ lands — and hidden entirely when no usable usage exists. Its fraction,
 threshold tone, and hover lines come from one pure projection.
 _Avoid_: token counter, usage widget
 
+**Setup tab**:
+A tab showing a new **worktree**'s bootstrap commands as they run — checkout,
+install, env — streamed from the daemon's `workspace_setup_progress` push,
+keyed by workspace. It opens when a worktree agent is created and hands off to
+that agent's conversation once setup succeeds, collapsing behind it to a
+summary chip that still holds the log; on failure the error and failing output
+stay visible inline. Non-worktree agents never get one.
+_Avoid_: bootstrap screen, install log
+
 **Tracks row**:
 A compact row above the composer surfacing live work as pills, each folded
 from the transcript's turns. The **Tasks pill** summarizes the latest todo

--- a/agent-directory/display-preferences.test.ts
+++ b/agent-directory/display-preferences.test.ts
@@ -11,24 +11,7 @@ import {
   type WorkspaceFilters,
 } from './display-preferences'
 import type { WorkspaceDescriptor } from '../daemon/paseo'
-
-function workspace(over: Partial<WorkspaceDescriptor>): WorkspaceDescriptor {
-  return {
-    id: over.id ?? 'w1',
-    projectId: over.projectId ?? 'p1',
-    projectDisplayName: over.projectDisplayName ?? 'storefront',
-    projectRootPath: over.projectRootPath ?? '/home/me/dev/storefront',
-    projectKind: 'git',
-    workspaceKind: 'directory',
-    name: over.name ?? 'storefront',
-    archivingAt: null,
-    status: 'running',
-    statusEnteredAt: null,
-    activityAt: '2026-08-24T10:00:00Z',
-    scripts: [],
-    ...over,
-  } as WorkspaceDescriptor
-}
+import { workspace } from './test-support'
 
 const script = (hostname: string) => ({
   scriptName: 'dev',

--- a/agent-directory/display-preferences.test.ts
+++ b/agent-directory/display-preferences.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  EMPTY_FILTERS,
+  LABEL_PALETTE,
+  UNLABELLED_LABEL,
+  filtersHideEverything,
+  hasActiveFilters,
+  labelColor,
+  workspaceHost,
+  workspaceMatchesFilters,
+  type WorkspaceFilters,
+} from './display-preferences'
+import type { WorkspaceDescriptor } from '../daemon/paseo'
+
+function workspace(over: Partial<WorkspaceDescriptor>): WorkspaceDescriptor {
+  return {
+    id: over.id ?? 'w1',
+    projectId: over.projectId ?? 'p1',
+    projectDisplayName: over.projectDisplayName ?? 'storefront',
+    projectRootPath: over.projectRootPath ?? '/home/me/dev/storefront',
+    projectKind: 'git',
+    workspaceKind: 'directory',
+    name: over.name ?? 'storefront',
+    archivingAt: null,
+    status: 'running',
+    statusEnteredAt: null,
+    activityAt: '2026-08-24T10:00:00Z',
+    scripts: [],
+    ...over,
+  } as WorkspaceDescriptor
+}
+
+const script = (hostname: string) => ({
+  scriptName: 'dev',
+  type: 'script' as const,
+  hostname,
+  port: 3000,
+  proxyUrl: null,
+  lifecycle: 'running' as const,
+  health: 'healthy' as const,
+  exitCode: null,
+  terminalId: null,
+})
+
+const filters = (over: Partial<WorkspaceFilters>): WorkspaceFilters => ({ ...EMPTY_FILTERS, ...over })
+
+describe('workspaceHost', () => {
+  test('every script agreeing on one hostname resolves that host', () => {
+    expect(workspaceHost(workspace({ scripts: [script('devbox'), script('devbox')] }))).toBe('devbox')
+  })
+
+  test('no scripts, or a split host, has no single host', () => {
+    expect(workspaceHost(workspace({ scripts: [] }))).toBeNull()
+    expect(workspaceHost(workspace({ scripts: [script('a'), script('b')] }))).toBeNull()
+  })
+})
+
+describe('workspaceMatchesFilters', () => {
+  test('empty filters match everything', () => {
+    expect(workspaceMatchesFilters(workspace({}), EMPTY_FILTERS)).toBe(true)
+  })
+
+  test('host filter keeps only workspaces on a selected host', () => {
+    const onBox = workspace({ id: 'a', scripts: [script('devbox')] })
+    const split = workspace({ id: 'b', scripts: [script('x'), script('y')] })
+    const f = filters({ hosts: ['devbox'] })
+    expect(workspaceMatchesFilters(onBox, f)).toBe(true)
+    expect(workspaceMatchesFilters(split, f)).toBe(false)
+    expect(workspaceMatchesFilters(workspace({ scripts: [] }), f)).toBe(false)
+  })
+
+  test('project allowlist matches by project id', () => {
+    const f = filters({ projects: ['p1'] })
+    expect(workspaceMatchesFilters(workspace({ projectId: 'p1' }), f)).toBe(true)
+    expect(workspaceMatchesFilters(workspace({ projectId: 'p2' }), f)).toBe(false)
+  })
+
+  test('label filter matches any selected label', () => {
+    const buggy = workspace({ labels: ['bug', 'perf'] })
+    const f = filters({ labels: ['bug'] })
+    expect(workspaceMatchesFilters(buggy, f)).toBe(true)
+    expect(workspaceMatchesFilters(workspace({ labels: ['docs'] }), f)).toBe(false)
+  })
+
+  test('Unlabelled matches workspaces with no labels at all, never labelled ones', () => {
+    const f = filters({ labels: [UNLABELLED_LABEL] })
+    expect(workspaceMatchesFilters(workspace({ labels: [] }), f)).toBe(true)
+    expect(workspaceMatchesFilters(workspace({ labels: undefined }), f)).toBe(true)
+    expect(workspaceMatchesFilters(workspace({ labels: ['bug'] }), f)).toBe(false)
+  })
+
+  test('dimensions compose with AND', () => {
+    const target = workspace({ id: 'a', projectId: 'p1', labels: ['bug'], scripts: [script('devbox')] })
+    expect(workspaceMatchesFilters(target, filters({ hosts: ['devbox'], projects: ['p1'], labels: ['bug'] }))).toBe(true)
+    // Break one dimension and it falls out despite matching the others.
+    expect(workspaceMatchesFilters(target, filters({ hosts: ['devbox'], projects: ['p2'], labels: ['bug'] }))).toBe(false)
+    expect(workspaceMatchesFilters(target, filters({ hosts: ['other'], projects: ['p1'], labels: ['bug'] }))).toBe(false)
+    expect(workspaceMatchesFilters(target, filters({ hosts: ['devbox'], projects: ['p1'], labels: ['docs'] }))).toBe(false)
+  })
+})
+
+describe('hasActiveFilters / filtersHideEverything', () => {
+  test('empty filters are inactive; any dimension makes them active', () => {
+    expect(hasActiveFilters(EMPTY_FILTERS)).toBe(false)
+    expect(hasActiveFilters(filters({ hosts: ['devbox'] }))).toBe(true)
+    expect(hasActiveFilters(filters({ projects: ['p1'] }))).toBe(true)
+    expect(hasActiveFilters(filters({ labels: ['bug'] }))).toBe(true)
+  })
+
+  test('filters hide everything only when active and nothing matches', () => {
+    const list = [workspace({ id: 'a', projectId: 'p1' })]
+    expect(filtersHideEverything(filters({ projects: ['p9'] }), list)).toBe(true)
+    expect(filtersHideEverything(filters({ projects: ['p1'] }), list)).toBe(false)
+    expect(filtersHideEverything(EMPTY_FILTERS, list)).toBe(false)
+  })
+})
+
+describe('labelColor', () => {
+  test('is deterministic: the same name always maps to the same color', () => {
+    expect(labelColor('bug')).toBe(labelColor('bug'))
+  })
+
+  test('only ever returns palette colors', () => {
+    for (const name of ['bug', 'perf', 'docs', 'frontend', 'backlog', 'x', 'very-long-label-name']) {
+      expect(LABEL_PALETTE).toContain(labelColor(name))
+    }
+  })
+
+  test('different labels can collide but each keeps one color', () => {
+    // The point is stability per label, not uniqueness across labels; assert
+    // the mapping is a function (same label -> same color) rather than unique.
+    const first = labelColor('alpha')
+    const second = labelColor('alpha')
+    expect(second).toBe(first)
+  })
+})

--- a/agent-directory/display-preferences.ts
+++ b/agent-directory/display-preferences.ts
@@ -1,0 +1,109 @@
+/**
+ * Sidebar display preferences (#44): the pure decisions behind the view
+ * menu's filters and the deterministic label-color scheme.
+ *
+ * Grouping (project | status) and the meta-line configuration live elsewhere
+ * (workspaces.ts, workspace-meta.ts); this module owns what those do not:
+ * the filter predicate with AND semantics across host / project / label, the
+ * host a workspace is said to live on, and the stable color every label dot
+ * renders. Nothing here touches the theme — colors come back raw so the
+ * chrome can consume them directly and #43/#45 can share the same scheme.
+ */
+
+import type { WorkspaceDescriptor } from '../daemon/paseo'
+
+// ---- filters ----------------------------------------------------------------
+
+/** The sentinel label-filter value meaning "workspaces with no labels at all". */
+export const UNLABELLED_LABEL = '*unlabelled*'
+
+/**
+ * The sidebar's active filters. Every list is an allowlist: an empty list
+ * means that dimension is not filtering. Different dimensions compose with
+ * AND — a workspace must match all non-empty dimensions to stay visible.
+ */
+export interface WorkspaceFilters {
+  /** Hostnames to show; empty shows every host. */
+  hosts: string[]
+  /** Project ids to show; empty shows every project. */
+  projects: string[]
+  /** Labels to show, plus the UNLABELLED_LABEL sentinel; empty shows all. */
+  labels: string[]
+}
+
+/** No active filters anywhere: the sidebar shows everything. */
+export const EMPTY_FILTERS: WorkspaceFilters = { hosts: [], projects: [], labels: [] }
+
+/** True when any of the three dimensions is actively filtering. */
+export function hasActiveFilters(filters: WorkspaceFilters): boolean {
+  return filters.hosts.length > 0 || filters.projects.length > 0 || filters.labels.length > 0
+}
+
+/** True when a filter combination exists but hides every workspace. */
+export function filtersHideEverything(filters: WorkspaceFilters, workspaces: WorkspaceDescriptor[]): boolean {
+  return hasActiveFilters(filters) && workspaces.every((descriptor) => !workspaceMatchesFilters(descriptor, filters))
+}
+
+/**
+ * The host a workspace lives on: the scripts' hostname, but only when every
+ * script agrees the workspace sits on one host. A script-less or split-host
+ * workspace has no single host and matches no host filter (a host allowlist
+ * hides it, which is the honest reading of "where does it run?").
+ */
+export function workspaceHost(descriptor: WorkspaceDescriptor): string | null {
+  const hostnames = new Set(descriptor.scripts.map((script) => script.hostname))
+  if (hostnames.size !== 1) return null
+  const hostname = [...hostnames][0]
+  return hostname ? hostname : null
+}
+
+/**
+ * Whether a workspace survives the current filters. AND across the host,
+ * project, and label dimensions; an empty dimension never filters. Unlabelled
+ * matches workspaces with no labels at all; otherwise a workspace shows when
+ * it carries at least one of the selected labels.
+ */
+export function workspaceMatchesFilters(descriptor: WorkspaceDescriptor, filters: WorkspaceFilters): boolean {
+  if (filters.hosts.length > 0) {
+    const host = workspaceHost(descriptor)
+    if (host == null || !filters.hosts.includes(host)) return false
+  }
+  if (filters.projects.length > 0 && !filters.projects.includes(descriptor.projectId)) return false
+  if (filters.labels.length > 0) {
+    const labels = descriptor.labels ?? []
+    const labelledMatch = labels.some((label) => filters.labels.includes(label))
+    const unlabelledMatch = filters.labels.includes(UNLABELLED_LABEL) && labels.length === 0
+    if (!labelledMatch && !unlabelledMatch) return false
+  }
+  return true
+}
+
+// ---- deterministic label colors --------------------------------------------
+
+/**
+ * A fixed, theme-independent palette the label dots cycle through. Raw hex so
+ * #43's label menu and #45's readouts share exactly the same scheme.
+ */
+export const LABEL_PALETTE: readonly string[] = [
+  '#E2795B',
+  '#58B368',
+  '#4C8DF6',
+  '#D9A050',
+  '#B76BE0',
+  '#5BD0CE',
+]
+
+/**
+ * One label name maps to one palette color, deterministically and forever: a
+ * workspace's label dot never changes color between runs or across surfaces.
+ * The scheme hashes the name to a stable index over LABEL_PALETTE; two labels
+ * may share a color, but one label never changes its own.
+ */
+export function labelColor(name: string): string {
+  let hash = 0
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0
+  }
+  const index = Math.abs(hash) % LABEL_PALETTE.length
+  return LABEL_PALETTE[index]!
+}

--- a/agent-directory/test-support.ts
+++ b/agent-directory/test-support.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared test support for the agent-directory seam.
+ *
+ * Workspace tests build descriptors the same way everywhere — a canonical
+ * minimal shape with runtime fields injected by `over` — so the one builder
+ * lives here instead of being copy-pasted per file. Keeping it in one place
+ * means the fixture's defaults stay in lockstep with the real descriptor.
+ */
+
+import type { WorkspaceDescriptor } from '../daemon/paseo'
+
+/** Canonical minimal descriptor builder; runtime fields arrive via `over`. */
+export function workspace(over: Partial<WorkspaceDescriptor>): WorkspaceDescriptor {
+  return {
+    id: over.id ?? 'w1',
+    projectId: over.projectId ?? 'p1',
+    projectDisplayName: over.projectDisplayName ?? 'storefront',
+    projectRootPath: over.projectRootPath ?? '/home/me/dev/storefront',
+    projectKind: 'git',
+    workspaceKind: 'directory',
+    name: over.name ?? 'storefront',
+    archivingAt: null,
+    status: 'running',
+    statusEnteredAt: null,
+    activityAt: over.activityAt ?? '2026-08-24T10:00:00Z',
+    scripts: [],
+    ...over,
+  } as WorkspaceDescriptor
+}

--- a/agent-directory/workspace-meta.test.ts
+++ b/agent-directory/workspace-meta.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_META_CONFIG,
+  META_TEXT_MAX,
+  truncateMetaText,
+  workspaceMetaLine,
+  workspaceRowTitle,
+  type WorkspaceMetaConfig,
+} from './workspace-meta'
+import type { WorkspaceDescriptor } from '../daemon/paseo'
+
+/** Canonical minimal descriptor builder; runtime fields arrive via `over`. */
+function workspace(over: Partial<WorkspaceDescriptor>): WorkspaceDescriptor {
+  return {
+    id: over.id ?? 'w1',
+    projectId: over.projectId ?? 'p1',
+    projectDisplayName: over.projectDisplayName ?? 'storefront',
+    projectRootPath: over.projectRootPath ?? '/home/me/dev/storefront',
+    projectKind: 'git',
+    workspaceKind: 'directory',
+    name: over.name ?? 'storefront',
+    archivingAt: null,
+    status: 'running',
+    statusEnteredAt: null,
+    activityAt: over.activityAt ?? '2026-08-24T10:00:00Z',
+    scripts: [],
+    ...over,
+  } as WorkspaceDescriptor
+}
+
+const git = (over: Partial<NonNullable<WorkspaceDescriptor['gitRuntime']>>) =>
+  ({ currentBranch: 'fix-auth', ...over }) as NonNullable<WorkspaceDescriptor['gitRuntime']>
+
+const pr = (over: Partial<NonNullable<NonNullable<WorkspaceDescriptor['githubRuntime']>['pullRequest']>>) =>
+  ({
+    number: 42,
+    url: 'https://github.com/me/storefront/pull/42',
+    title: 'Fix auth',
+    state: 'OPEN',
+    baseRefName: 'main',
+    headRefName: 'fix-auth',
+    isMerged: false,
+    ...over,
+  }) as NonNullable<NonNullable<WorkspaceDescriptor['githubRuntime']>['pullRequest']>
+
+const check = (status: 'success' | 'pending' | 'failure' | 'skipped' | 'cancelled') => ({
+  name: `check-${status}`,
+  status,
+  url: null,
+})
+
+const service = (
+  over: Partial<{ lifecycle: 'running' | 'stopped'; health: 'healthy' | 'unhealthy' | null; type: 'script' | 'service'; hostname: string }>,
+) => ({
+  scriptName: 'dev',
+  type: 'service' as const,
+  hostname: 'devbox',
+  port: 3000,
+  proxyUrl: null,
+  lifecycle: 'running' as const,
+  health: 'healthy' as const,
+  exitCode: null,
+  terminalId: null,
+  ...over,
+})
+
+const withSlots = (slots: Partial<WorkspaceMetaConfig['slots']>): WorkspaceMetaConfig => ({
+  ...DEFAULT_META_CONFIG,
+  slots: { ...DEFAULT_META_CONFIG.slots, ...slots },
+})
+
+describe('branch slot', () => {
+  test('renders the current branch with dirty and ahead-behind indicators', () => {
+    const line = workspaceMetaLine(workspace({ gitRuntime: git({ isDirty: true, aheadBehind: { ahead: 1, behind: 2 } }) }))
+    expect(line.items[0]).toEqual({ kind: 'branch', text: 'fix-auth', tone: 'neutral', dirty: true, aheadBehind: '↑1 ↓2' })
+  })
+
+  test('hides zero sides of ahead-behind', () => {
+    const line = workspaceMetaLine(workspace({ gitRuntime: git({ aheadBehind: { ahead: 0, behind: 3 } }) }))
+    expect(line.items[0]).toMatchObject({ aheadBehind: '↓3' })
+  })
+
+  test('a clean synced branch shows no indicators', () => {
+    const line = workspaceMetaLine(workspace({ gitRuntime: git() }))
+    expect(line.items[0]).toEqual({ kind: 'branch', text: 'fix-auth', tone: 'neutral', dirty: false, aheadBehind: null })
+  })
+
+  test('missing gitRuntime or an unknown branch renders nothing', () => {
+    expect(workspaceMetaLine(workspace({ gitRuntime: null })).items).toEqual([])
+    expect(workspaceMetaLine(workspace({ gitRuntime: git({ currentBranch: null }) })).items).toEqual([])
+    expect(workspaceMetaLine(workspace({ gitRuntime: git({ currentBranch: '   ' }) })).items).toEqual([])
+  })
+
+  test('a runaway branch name truncates with an ellipsis at the cap', () => {
+    const branch = 'fix/very-long-descriptive-branch-name-here'
+    const line = workspaceMetaLine(workspace({ gitRuntime: git({ currentBranch: branch }) }))
+    expect(line.items[0]).toMatchObject({ text: `${branch.slice(0, META_TEXT_MAX)}…` })
+  })
+})
+
+describe('pull request slot', () => {
+  test('renders number and state from githubRuntime', () => {
+    const line = workspaceMetaLine(workspace({ githubRuntime: { pullRequest: pr() } }))
+    expect(line.items[0]).toEqual({ kind: 'pullRequest', text: '#42', detail: 'open', tone: 'neutral' })
+  })
+
+  test('a merged PR reads merged in the ok tone; draft beats a plain state', () => {
+    const merged = workspaceMetaLine(workspace({ githubRuntime: { pullRequest: pr({ isMerged: true }) } }))
+    expect(merged.items[0]).toMatchObject({ detail: 'merged', tone: 'ok' })
+    const draft = workspaceMetaLine(workspace({ githubRuntime: { pullRequest: pr({ isDraft: true }) } }))
+    expect(draft.items[0]).toMatchObject({ detail: 'draft', tone: 'neutral' })
+  })
+
+  test('state text lowercases whatever casing the daemon sends', () => {
+    const line = workspaceMetaLine(workspace({ githubRuntime: { pullRequest: pr({ state: 'CLOSED' }) } }))
+    expect(line.items[0]).toMatchObject({ detail: 'closed' })
+  })
+
+  test('a PR without a number still carries its state', () => {
+    const line = workspaceMetaLine(workspace({ githubRuntime: { pullRequest: pr({ number: undefined }) } }))
+    expect(line.items[0]).toEqual({ kind: 'pullRequest', text: 'open', detail: null, tone: 'neutral' })
+  })
+
+  test('no githubRuntime or no pullRequest renders nothing, never a placeholder', () => {
+    expect(workspaceMetaLine(workspace({ githubRuntime: null })).items).toEqual([])
+    expect(workspaceMetaLine(workspace({ githubRuntime: { pullRequest: null } })).items).toEqual([])
+  })
+})
+
+describe('checks', () => {
+  test('icon+text default shows passed/total from the individual runs', () => {
+    const line = workspaceMetaLine(
+      workspace({ githubRuntime: { pullRequest: pr({ checks: [check('success'), check('success'), check('failure')], checksStatus: 'failure' }) } }),
+    )
+    expect(line.checks).toEqual({ status: 'failure', label: '2/3' })
+  })
+
+  test('skipped runs count as passed; cancelled does not', () => {
+    const line = workspaceMetaLine(
+      workspace({ githubRuntime: { pullRequest: pr({ checks: [check('success'), check('skipped'), check('cancelled')], checksStatus: 'success' }) } }),
+    )
+    expect(line.checks).toEqual({ status: 'success', label: '2/3' })
+  })
+
+  test('checksStatus wins over the runs when supplied; otherwise derive worst-of', () => {
+    const supplied = workspaceMetaLine(
+      workspace({ githubRuntime: { pullRequest: pr({ checks: [check('success')], checksStatus: 'pending' }) } }),
+    )
+    expect(supplied.checks).toMatchObject({ status: 'pending' })
+    const derived = workspaceMetaLine(workspace({ githubRuntime: { pullRequest: pr({ checks: [check('pending'), check('success')] }) } }))
+    expect(derived.checks).toMatchObject({ status: 'pending' })
+    const clean = workspaceMetaLine(workspace({ githubRuntime: { pullRequest: pr({ checks: [check('success'), check('success')] }) } }))
+    expect(clean.checks).toMatchObject({ status: 'success' })
+  })
+
+  test('no runs and no status, or checksStatus none, renders nothing', () => {
+    expect(workspaceMetaLine(workspace({ githubRuntime: { pullRequest: pr({ checks: [] }) } })).checks).toBeNull()
+    const none = workspaceMetaLine(
+      workspace({ githubRuntime: { pullRequest: pr({ checks: [check('success')], checksStatus: 'none' }) } }),
+    )
+    expect(none.checks).toBeNull()
+  })
+
+  test('icon-only mode drops the label; hidden mode drops the checks entirely', () => {
+    const descriptor = workspace({ githubRuntime: { pullRequest: pr({ checks: [check('success'), check('failure')] }) } })
+    expect(workspaceMetaLine(descriptor, { ...DEFAULT_META_CONFIG, checksMode: 'iconOnly' }).checks).toEqual({ status: 'failure', label: null })
+    expect(workspaceMetaLine(descriptor, { ...DEFAULT_META_CONFIG, checksMode: 'hidden' }).checks).toBeNull()
+  })
+
+  test('checks answer to their own toggle and render even with the PR slot off', () => {
+    const descriptor = workspace({ githubRuntime: { pullRequest: pr({ checks: [check('success')] }) } })
+    expect(workspaceMetaLine(descriptor, withSlots({ pullRequest: false })).checks).toEqual({ status: 'success', label: '1/1' })
+  })
+})
+
+describe('services slot', () => {
+  test('shows running/total of daemon-typed services', () => {
+    const line = workspaceMetaLine(
+      workspace({ scripts: [service({ scriptName: 'api' }), service({ scriptName: 'web' }), service({ scriptName: 'db', lifecycle: 'stopped' })] }),
+    )
+    expect(line.items[0]).toEqual({ kind: 'services', text: '2/3', tone: 'neutral' })
+  })
+
+  test('all running reads ok; one unhealthy reads danger', () => {
+    const healthy = workspaceMetaLine(workspace({ scripts: [service({}), service({})] }))
+    expect(healthy.items[0]).toMatchObject({ tone: 'ok' })
+    const sick = workspaceMetaLine(workspace({ scripts: [service({}), service({ health: 'unhealthy' })] }))
+    expect(sick.items[0]).toMatchObject({ tone: 'danger' })
+  })
+
+  test('scripts typed as scripts are not services', () => {
+    const line = workspaceMetaLine(workspace({ scripts: [service({ type: 'script' })] }))
+    expect(line.items).toEqual([])
+  })
+
+  test('no scripts renders nothing', () => {
+    expect(workspaceMetaLine(workspace({ scripts: [] })).items).toEqual([])
+  })
+})
+
+describe('project, host, and labels slots', () => {
+  test('project shows the custom name when the user set one', () => {
+    const line = workspaceMetaLine(
+      workspace({ projectDisplayName: 'storefront', projectCustomName: 'Shop' }),
+      withSlots({ project: true }),
+    )
+    expect(line.items[0]).toEqual({ kind: 'project', text: 'Shop', tone: 'neutral' })
+  })
+
+  test('host renders only when every script agrees on one hostname', () => {
+    const one = workspaceMetaLine(workspace({ scripts: [service({}), service({ hostname: 'devbox' })] }), withSlots({ host: true }))
+    expect(one.items[0]).toMatchObject({ kind: 'host', text: 'devbox' })
+    const split = workspaceMetaLine(workspace({ scripts: [service({}), service({ hostname: 'other' })] }), withSlots({ host: true }))
+    expect(split.items.some((item) => item.kind === 'host')).toBe(false)
+    const none = workspaceMetaLine(workspace({ scripts: [] }), withSlots({ host: true }))
+    expect(none.items.some((item) => item.kind === 'host')).toBe(false)
+  })
+
+  test('labels default hidden; enabled they join, truncate, and skip empties', () => {
+    expect(workspaceMetaLine(workspace({ labels: ['bug', 'perf'] })).items).toEqual([])
+    const line = workspaceMetaLine(workspace({ labels: ['bug', 'perf'] }), withSlots({ labels: true }))
+    expect(line.items[0]).toEqual({ kind: 'labels', text: 'bug, perf', tone: 'neutral' })
+    expect(workspaceMetaLine(workspace({ labels: [] }), withSlots({ labels: true })).items).toEqual([])
+  })
+
+  test('items render in fixed slot order regardless of data order', () => {
+    const line = workspaceMetaLine(
+      workspace({
+        labels: ['bug'],
+        scripts: [service({})],
+        gitRuntime: git(),
+        githubRuntime: { pullRequest: pr() },
+      }),
+      withSlots({ project: true, host: true, labels: true }),
+    )
+    expect(line.items.map((item) => item.kind)).toEqual(['branch', 'project', 'host', 'pullRequest', 'services', 'labels'])
+  })
+})
+
+describe('trailing slot', () => {
+  test('diff stat is the default and passes the raw numbers through', () => {
+    const line = workspaceMetaLine(workspace({ diffStat: { additions: 12, deletions: 3 } }))
+    expect(line.trailing).toEqual({ kind: 'diffStat', additions: 12, deletions: 3 })
+  })
+
+  test('a null diffStat or a zeroed one renders nothing', () => {
+    expect(workspaceMetaLine(workspace({ diffStat: null })).trailing).toBeNull()
+    expect(workspaceMetaLine(workspace({ diffStat: { additions: 0, deletions: 0 } })).trailing).toBeNull()
+  })
+
+  test('the activity alternative resolves the epoch timestamp of last activity', () => {
+    const config = { ...DEFAULT_META_CONFIG, trailing: 'activity' as const }
+    const line = workspaceMetaLine(workspace({ activityAt: '2026-08-24T10:00:00Z' }), config)
+    expect(line.trailing).toEqual({ kind: 'activity', at: Date.parse('2026-08-24T10:00:00Z') })
+  })
+
+  test('a workspace with no activity renders no activity trailing', () => {
+    const config = { ...DEFAULT_META_CONFIG, trailing: 'activity' as const }
+    expect(workspaceMetaLine(workspace({ activityAt: null }), config).trailing).toBeNull()
+  })
+})
+
+describe('title', () => {
+  test('an explicit override wins over the derived name', () => {
+    expect(workspaceRowTitle(workspace({ title: 'My Workspace', name: 'storefront' }))).toBe('My Workspace')
+    expect(workspaceRowTitle(workspace({ name: 'storefront' }))).toBe('storefront')
+  })
+
+  test('the branch-name source swaps in the current branch when known', () => {
+    const config = { ...DEFAULT_META_CONFIG, titleSource: 'branch' as const }
+    expect(workspaceRowTitle(workspace({ gitRuntime: git() }), config)).toBe('fix-auth')
+    expect(workspaceRowTitle(workspace({ name: 'storefront' }), config)).toBe('storefront')
+  })
+})
+
+describe('graceful degradation', () => {
+  test('a bare descriptor resolves an empty line with no placeholders', () => {
+    expect(workspaceMetaLine(workspace({}))).toEqual({ items: [], checks: null, trailing: null })
+  })
+})
+
+describe('truncateMetaText', () => {
+  test('keeps the cap plus an ellipsis; short text passes through', () => {
+    expect(truncateMetaText('abcdefgh', 4)).toBe('abcd…')
+    expect(truncateMetaText('abc', 4)).toBe('abc')
+    expect(truncateMetaText('abcdefgh', META_TEXT_MAX)).toBe('abcdefgh')
+  })
+})

--- a/agent-directory/workspace-meta.test.ts
+++ b/agent-directory/workspace-meta.test.ts
@@ -8,25 +8,7 @@ import {
   type WorkspaceMetaConfig,
 } from './workspace-meta'
 import type { WorkspaceDescriptor } from '../daemon/paseo'
-
-/** Canonical minimal descriptor builder; runtime fields arrive via `over`. */
-function workspace(over: Partial<WorkspaceDescriptor>): WorkspaceDescriptor {
-  return {
-    id: over.id ?? 'w1',
-    projectId: over.projectId ?? 'p1',
-    projectDisplayName: over.projectDisplayName ?? 'storefront',
-    projectRootPath: over.projectRootPath ?? '/home/me/dev/storefront',
-    projectKind: 'git',
-    workspaceKind: 'directory',
-    name: over.name ?? 'storefront',
-    archivingAt: null,
-    status: 'running',
-    statusEnteredAt: null,
-    activityAt: over.activityAt ?? '2026-08-24T10:00:00Z',
-    scripts: [],
-    ...over,
-  } as WorkspaceDescriptor
-}
+import { workspace } from './test-support'
 
 const git = (over: Partial<NonNullable<WorkspaceDescriptor['gitRuntime']>>) =>
   ({ currentBranch: 'fix-auth', ...over }) as NonNullable<WorkspaceDescriptor['gitRuntime']>

--- a/agent-directory/workspace-meta.ts
+++ b/agent-directory/workspace-meta.ts
@@ -1,0 +1,292 @@
+/**
+ * Workspace row meta line (#42).
+ *
+ * One pure seam decides everything the row's second line shows: which slots
+ * render (branch, project, host, pull request, services, labels), whether CI
+ * checks render icon+text, icon-only, or not at all, what the trailing slot
+ * holds (diff stats or last activity), and how long any one item may run
+ * before it truncates. All data comes from the descriptor's own fields
+ * (gitRuntime, githubRuntime, diffStat, scripts, labels); nothing is fetched
+ * or invented here.
+ *
+ * Degradation rule: a slot with no backing data resolves to nothing and takes
+ * no space — never a placeholder, never dead width. A row whose line resolves
+ * to nothing at all renders without a second line.
+ *
+ * The toggling menu lives with display preferences (#44); until then the row
+ * renders the DEFAULT_META_CONFIG below, chosen to mirror upstream: branch,
+ * pull request, services, and icon+text checks on; project and host off (the
+ * surrounding group header already names the project); labels off; trailing
+ * slot on diff stats.
+ */
+
+import type { WorkspaceDescriptor } from '../daemon/paseo'
+import { projectName, workspaceActivityAt, workspaceDisplayName } from './workspaces'
+
+// ---- configuration -------------------------------------------------------------
+
+/** The six toggleable meta-line slots, in their left-to-right render order. */
+export type MetaSlotKind = 'branch' | 'project' | 'host' | 'pullRequest' | 'services' | 'labels'
+
+/** Checks rendering: icon plus a "3/5" label, the icon alone, or nothing. */
+export type ChecksMode = 'iconText' | 'iconOnly' | 'hidden'
+
+/** The trailing slot: diff stats (additions/deletions) or relative last activity. */
+export type TrailingSlot = 'diffStat' | 'activity'
+
+/** The row title: the workspace's display name or its current branch. */
+export type TitleSource = 'title' | 'branch'
+
+export interface WorkspaceMetaConfig {
+  slots: Record<MetaSlotKind, boolean>
+  checksMode: ChecksMode
+  trailing: TrailingSlot
+  titleSource: TitleSource
+}
+
+/**
+ * The defaults that ship now. `trailing: 'diffStat'` mirrors upstream's own
+ * default; switching to last activity is a display-preferences choice (#44).
+ */
+export const DEFAULT_META_CONFIG: WorkspaceMetaConfig = {
+  slots: {
+    branch: true,
+    project: false,
+    host: false,
+    pullRequest: true,
+    services: true,
+    labels: false,
+  },
+  checksMode: 'iconText',
+  trailing: 'diffStat',
+  titleSource: 'title',
+}
+
+// ---- resolved shapes -----------------------------------------------------------
+
+/** Coarse color hint for chrome; keeps this module free of theme imports. */
+export type MetaTone = 'neutral' | 'ok' | 'warn' | 'danger' | 'accent'
+
+export type WorkspaceMetaItem =
+  | { kind: 'branch'; text: string; tone: 'neutral'; dirty: boolean; aheadBehind: string | null }
+  | { kind: 'project'; text: string; tone: 'neutral' }
+  | { kind: 'host'; text: string; tone: 'neutral' }
+  | { kind: 'pullRequest'; text: string; detail: string | null; tone: MetaTone }
+  | { kind: 'services'; text: string; tone: MetaTone }
+  | { kind: 'labels'; text: string; tone: 'neutral' }
+
+export interface WorkspaceMetaChecks {
+  status: 'success' | 'pending' | 'failure'
+  /** The iconText label ("3/5"); null renders the icon alone. */
+  label: string | null
+}
+
+export type WorkspaceMetaTrailing =
+  | { kind: 'diffStat'; additions: number; deletions: number }
+  | { kind: 'activity'; at: number }
+
+export interface WorkspaceMetaLine {
+  items: WorkspaceMetaItem[]
+  checks: WorkspaceMetaChecks | null
+  trailing: WorkspaceMetaTrailing | null
+}
+
+// ---- text shaping --------------------------------------------------------------
+
+/**
+ * Hard cap on any one item's text; the row's CSS ellipsis handles the rest of
+ * the squeeze, but a single absurd branch or label run should never starve
+ * every slot after it.
+ */
+export const META_TEXT_MAX = 24
+
+/** End-ellipsis truncation; exactly `max` characters survive plus the ellipsis. */
+export function truncateMetaText(text: string, max: number = META_TEXT_MAX): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text
+}
+
+/**
+ * Compact "↑n ↓m" summary; zero sides hide, an empty summary is null. Same
+ * shape as checkout's formatAheadBehind, kept seam-local so the directory
+ * never depends on the checkout seam.
+ */
+function formatAheadBehind(ahead: number, behind: number): string | null {
+  const up = ahead > 0 ? `↑${ahead}` : null
+  const down = behind > 0 ? `↓${behind}` : null
+  if (up && down) return `${up} ${down}`
+  return up ?? down
+}
+
+// ---- slot resolution -----------------------------------------------------------
+
+function branchItem(descriptor: WorkspaceDescriptor): WorkspaceMetaItem | null {
+  const branch = descriptor.gitRuntime?.currentBranch?.trim()
+  if (!branch) return null
+  const git = descriptor.gitRuntime
+  const aheadBehind = git?.aheadBehind ? formatAheadBehind(git.aheadBehind.ahead, git.aheadBehind.behind) : null
+  return {
+    kind: 'branch',
+    text: truncateMetaText(branch),
+    tone: 'neutral',
+    dirty: git?.isDirty === true,
+    aheadBehind,
+  }
+}
+
+function projectItem(descriptor: WorkspaceDescriptor): WorkspaceMetaItem {
+  return { kind: 'project', text: truncateMetaText(projectName(descriptor)), tone: 'neutral' }
+}
+
+/**
+ * The descriptor carries no host of its own; the scripts' hostname is the only
+ * source today, and only when every script agrees the workspace lives on one
+ * host — a split-host workspace says nothing rather than a wrong half.
+ */
+function hostItem(descriptor: WorkspaceDescriptor): WorkspaceMetaItem | null {
+  const hostnames = new Set(descriptor.scripts.map((script) => script.hostname))
+  if (hostnames.size !== 1) return null
+  const hostname = [...hostnames][0]
+  return hostname ? { kind: 'host', text: truncateMetaText(hostname), tone: 'neutral' } : null
+}
+
+function pullRequestItem(descriptor: WorkspaceDescriptor): WorkspaceMetaItem | null {
+  const pr = descriptor.githubRuntime?.pullRequest
+  if (!pr) return null
+  const detail = pr.isMerged ? 'merged' : pr.isDraft ? 'draft' : (pr.state.trim().toLowerCase() || null)
+  if (!detail) return null
+  // With a number the item reads "#42 open"; without one the state word alone
+  // still carries the standing — that is data, not a placeholder.
+  const text = pr.number != null ? `#${pr.number}` : detail
+  return {
+    kind: 'pullRequest',
+    text,
+    detail: pr.number != null ? detail : null,
+    tone: pr.isMerged ? 'ok' : 'neutral',
+  }
+}
+
+/**
+ * Services are the scripts the daemon typed as such; "running/total" with the
+ * tone going danger the moment one is unhealthy and ok only while every one
+ * of them runs.
+ */
+function servicesItem(descriptor: WorkspaceDescriptor): WorkspaceMetaItem | null {
+  const services = descriptor.scripts.filter((script) => script.type === 'service')
+  if (services.length === 0) return null
+  const running = services.filter((script) => script.lifecycle === 'running').length
+  const tone: MetaTone = services.some((script) => script.health === 'unhealthy')
+    ? 'danger'
+    : running === services.length
+      ? 'ok'
+      : 'neutral'
+  return { kind: 'services', text: `${running}/${services.length}`, tone }
+}
+
+function labelsItem(descriptor: WorkspaceDescriptor): WorkspaceMetaItem | null {
+  const labels = descriptor.labels ?? []
+  if (labels.length === 0) return null
+  return { kind: 'labels', text: truncateMetaText(labels.join(', ')), tone: 'neutral' }
+}
+
+// ---- checks ---------------------------------------------------------------------
+
+/**
+ * The run status: the daemon's own checksStatus when supplied, otherwise the
+ * worst of the individual runs — any failure fails, else any pending pends.
+ * Skipped runs count as passed for the label; they resolved, they just did no
+ * work.
+ */
+function resolveChecks(
+  pr: NonNullable<NonNullable<WorkspaceDescriptor['githubRuntime']>['pullRequest']>,
+  mode: ChecksMode,
+): WorkspaceMetaChecks | null {
+  if (mode === 'hidden') return null
+  const checks = pr.checks ?? []
+  const status = pr.checksStatus ?? deriveChecksStatus(checks)
+  if (status === 'none' || status == null) return null
+  if (mode === 'iconOnly' || checks.length === 0) return { status, label: null }
+  const passed = checks.filter((check) => check.status === 'success' || check.status === 'skipped').length
+  return { status, label: `${passed}/${checks.length}` }
+}
+
+type PullRequestChecks = NonNullable<
+  NonNullable<NonNullable<WorkspaceDescriptor['githubRuntime']>['pullRequest']>['checks']
+>
+
+function deriveChecksStatus(checks: PullRequestChecks): 'success' | 'pending' | 'failure' | null {
+  if (checks.length === 0) return null
+  if (checks.some((check) => check.status === 'failure')) return 'failure'
+  if (checks.some((check) => check.status === 'pending')) return 'pending'
+  return 'success'
+}
+
+// ---- trailing slot ---------------------------------------------------------------
+
+function resolveTrailing(descriptor: WorkspaceDescriptor, trailing: TrailingSlot): WorkspaceMetaTrailing | null {
+  if (trailing === 'activity') {
+    const at = workspaceActivityAt(descriptor)
+    // A descriptor with no activityAt maps to the epoch; a date from 1970 is a
+    // placeholder in disguise, so the slot stays empty instead.
+    return at > 0 ? { kind: 'activity', at } : null
+  }
+  const diffStat = descriptor.diffStat
+  if (!diffStat) return null
+  // Zero additions and zero deletions has nothing to say; the pill would hide
+  // its zero sides anyway and read as an empty pair of signs.
+  if (diffStat.additions <= 0 && diffStat.deletions <= 0) return null
+  return { kind: 'diffStat', additions: diffStat.additions, deletions: diffStat.deletions }
+}
+
+// ---- resolution ------------------------------------------------------------------
+
+/**
+ * The whole meta line for one workspace: slot items in fixed order, the checks
+ * readout, and the trailing slot. Pure over (descriptor, config).
+ */
+export function workspaceMetaLine(
+  descriptor: WorkspaceDescriptor,
+  config: WorkspaceMetaConfig = DEFAULT_META_CONFIG,
+): WorkspaceMetaLine {
+  const items: WorkspaceMetaItem[] = []
+  if (config.slots.branch) {
+    const item = branchItem(descriptor)
+    if (item) items.push(item)
+  }
+  if (config.slots.project) items.push(projectItem(descriptor))
+  if (config.slots.host) {
+    const item = hostItem(descriptor)
+    if (item) items.push(item)
+  }
+  if (config.slots.pullRequest) {
+    const item = pullRequestItem(descriptor)
+    if (item) items.push(item)
+  }
+  if (config.slots.services) {
+    const item = servicesItem(descriptor)
+    if (item) items.push(item)
+  }
+  if (config.slots.labels) {
+    const item = labelsItem(descriptor)
+    if (item) items.push(item)
+  }
+  // Checks ride on the pull request's data but answer to their own toggle, so
+  // they can render even when the PR slot itself is off.
+  const pr = descriptor.githubRuntime?.pullRequest
+  const checks = pr ? resolveChecks(pr, config.checksMode) : null
+  return { items, checks, trailing: resolveTrailing(descriptor, config.trailing) }
+}
+
+/**
+ * The row title: an explicit override always wins over derived names; the
+ * branch-name source swaps in the current branch when the daemon knows one.
+ */
+export function workspaceRowTitle(
+  descriptor: WorkspaceDescriptor,
+  config: WorkspaceMetaConfig = DEFAULT_META_CONFIG,
+): string {
+  if (config.titleSource === 'branch') {
+    const branch = descriptor.gitRuntime?.currentBranch?.trim()
+    if (branch) return branch
+  }
+  return workspaceDisplayName(descriptor)
+}

--- a/agent-directory/workspace-mutations.test.ts
+++ b/agent-directory/workspace-mutations.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  workspaceLabelColor,
+  workspaceMutations,
+  type WorkspaceMutationsClient,
+} from './workspace-mutations'
+
+/** Records every mutation call in order, echoing the daemon's stubs. */
+function recordingClient(calls: string[]): WorkspaceMutationsClient {
+  return {
+    setWorkspaceTitle: async (workspaceId, title) => {
+      calls.push(`title:${workspaceId}:${JSON.stringify(title)}`)
+      return { title }
+    },
+    setWorkspacePinned: async (workspaceId, pinned) => {
+      calls.push(`pin:${workspaceId}:${pinned}`)
+      return { pinnedAt: pinned ? '2026-08-24T09:00:00Z' : null }
+    },
+    clearWorkspaceAttention: async (workspaceId) => {
+      calls.push(`attention:${workspaceId}`)
+    },
+    setWorkspaceLabel: async (options) => {
+      calls.push(`label:${options.workspaceId}:${options.label.name}:${options.label.color}:${options.assigned}`)
+      return {}
+    },
+    archiveWorkspace: async (workspaceId) => {
+      calls.push(`archive:${workspaceId}`)
+      return { archivedAt: '2026-08-24T09:00:00Z' }
+    },
+  }
+}
+
+describe('workspaceMutations', () => {
+  test('setTitle calls setWorkspaceTitle as-is', async () => {
+    const calls: string[] = []
+    await workspaceMutations(recordingClient(calls)).setTitle('w1', 'Fix login')
+    expect(calls).toEqual(['title:w1:"Fix login"'])
+  })
+
+  test('setTitle with null restores the derived title', async () => {
+    const calls: string[] = []
+    await workspaceMutations(recordingClient(calls)).setTitle('w1', null)
+    expect(calls).toEqual(['title:w1:null'])
+  })
+
+  test('setPinned forwards the pinned boolean', async () => {
+    const calls: string[] = []
+    const mutations = workspaceMutations(recordingClient(calls))
+    await mutations.setPinned('w1', true)
+    await mutations.setPinned('w1', false)
+    expect(calls).toEqual(['pin:w1:true', 'pin:w1:false'])
+  })
+
+  test('clearAttention forwards the workspace id', async () => {
+    const calls: string[] = []
+    await workspaceMutations(recordingClient(calls)).clearAttention('w1')
+    expect(calls).toEqual(['attention:w1'])
+  })
+
+  test('toggleLabel shapes the assignment payload with a deterministic colour', async () => {
+    const calls: string[] = []
+    const mutations = workspaceMutations(recordingClient(calls))
+    await mutations.toggleLabel('w1', 'frontend', true)
+    await mutations.toggleLabel('w1', 'frontend', false)
+    const color = workspaceLabelColor('frontend')
+    expect(calls).toEqual([
+      `label:w1:frontend:${color}:true`,
+      `label:w1:frontend:${color}:false`,
+    ])
+    expect(color).toMatch(/^(violet|sky|emerald|orange|pink|indigo|teal|red|amber|blue)$/)
+  })
+
+  test('toggleLabel trims the name before pairing it with a colour', async () => {
+    const calls: string[] = []
+    await workspaceMutations(recordingClient(calls)).toggleLabel('w1', '  api  ', true)
+    expect(calls).toEqual([`label:w1:api:${workspaceLabelColor('api')}:true`])
+  })
+
+  test('clearLabels removes every applied label', async () => {
+    const calls: string[] = []
+    const mutations = workspaceMutations(recordingClient(calls))
+    await mutations.clearLabels('w1', ['alpha', 'beta'])
+    expect(calls).toEqual([
+      `label:w1:alpha:${workspaceLabelColor('alpha')}:false`,
+      `label:w1:beta:${workspaceLabelColor('beta')}:false`,
+    ])
+  })
+
+  test('clearLabels with nothing applied sends no calls', async () => {
+    const calls: string[] = []
+    await workspaceMutations(recordingClient(calls)).clearLabels('w1', [])
+    expect(calls).toEqual([])
+  })
+
+  test('archive calls archiveWorkspace', async () => {
+    const calls: string[] = []
+    await workspaceMutations(recordingClient(calls)).archive('w1')
+    expect(calls).toEqual(['archive:w1'])
+  })
+
+  test('a rejected daemon call propagates to the awaiting UI', async () => {
+    const rejecting: WorkspaceMutationsClient = {
+      setWorkspaceTitle: () => Promise.reject(new Error('nope')),
+      setWorkspacePinned: () => Promise.reject(new Error('nope')),
+      clearWorkspaceAttention: () => Promise.reject(new Error('nope')),
+      setWorkspaceLabel: () => Promise.reject(new Error('nope')),
+      archiveWorkspace: () => Promise.reject(new Error('nope')),
+    }
+    const mutations = workspaceMutations(rejecting)
+    await expect(mutations.setTitle('w1', 'x')).rejects.toThrow('nope')
+    await expect(mutations.setPinned('w1', true)).rejects.toThrow('nope')
+    await expect(mutations.clearAttention('w1')).rejects.toThrow('nope')
+    await expect(mutations.toggleLabel('w1', 'x', true)).rejects.toThrow('nope')
+    await expect(mutations.archive('w1')).rejects.toThrow('nope')
+  })
+})
+
+describe('workspaceLabelColor', () => {
+  test('is deterministic per name', () => {
+    expect(workspaceLabelColor('frontend')).toBe(workspaceLabelColor('frontend'))
+    expect(workspaceLabelColor('api')).toBe(workspaceLabelColor('api'))
+  })
+
+  test('maps to the protocol colour vocabulary only', () => {
+    const allowed = ['violet', 'sky', 'emerald', 'orange', 'pink', 'indigo', 'teal', 'red', 'amber', 'blue']
+    for (const name of ['a', 'b', 'c', 'zz', 'frontend', 'api', 'urgent']) {
+      expect(allowed).toContain(workspaceLabelColor(name))
+    }
+  })
+
+  test('spreads across colours for varied names', () => {
+    const seen = new Set(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight'].map(workspaceLabelColor))
+    expect(seen.size).toBeGreaterThan(1)
+  })
+})

--- a/agent-directory/workspace-mutations.ts
+++ b/agent-directory/workspace-mutations.ts
@@ -1,0 +1,101 @@
+/**
+ * Workspace row mutations: title, pin, mark-as-read, labels, archive.
+ *
+ * Each mutation is a thin wrapper around the low-level DaemonClient whose
+ * promise the UI awaits for in-flight disabling; the directory store is never
+ * written here. Truth continues to arrive exclusively through the subscription
+ * path (`applyWorkspaceUpdate` already folds pinned/labelled/titled snapshots),
+ * so a settled wrapper only means the daemon accepted the call.
+ *
+ * The wrapper earns its keep where the SDK stops short: the label RPC's payload
+ * needs a colour alongside the name, but the workspace descriptor only carries
+ * label names. `toggleLabel` pairs a name with a deterministic colour so the
+ * daemon's `workspace.label.assignment.set` shape is satisfied without the UI
+ * knowing anything about colour.
+ */
+
+/** The ten colour names the workspace-label protocol accepts. */
+export type WorkspaceLabelColor =
+  | 'violet'
+  | 'sky'
+  | 'emerald'
+  | 'orange'
+  | 'pink'
+  | 'indigo'
+  | 'teal'
+  | 'red'
+  | 'amber'
+  | 'blue'
+
+const LABEL_COLORS: readonly WorkspaceLabelColor[] = [
+  'violet',
+  'sky',
+  'emerald',
+  'orange',
+  'pink',
+  'indigo',
+  'teal',
+  'red',
+  'amber',
+  'blue',
+]
+
+/**
+ * A label's colour, chosen deterministically from its name so the same label
+ * always carries the same colour and label toggling stays idempotent. The
+ * descriptor carries only label names; the daemon's assignment RPC wants a
+ * colour too, and hashing the name satisfies that shape without any catalog.
+ */
+export function workspaceLabelColor(name: string): WorkspaceLabelColor {
+  let hash = 0
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0
+  return LABEL_COLORS[Math.abs(hash) % LABEL_COLORS.length]!
+}
+
+/** The slice of the daemon client the workspace mutations need. */
+export interface WorkspaceMutationsClient {
+  setWorkspaceTitle(workspaceId: string, title: string | null): Promise<unknown>
+  setWorkspacePinned(workspaceId: string, pinned: boolean): Promise<unknown>
+  clearWorkspaceAttention(workspaceId: string | string[]): Promise<void>
+  setWorkspaceLabel(options: {
+    workspaceId: string
+    label: { name: string; color: WorkspaceLabelColor }
+    assigned: boolean
+  }): Promise<unknown>
+  archiveWorkspace(workspaceId: string): Promise<unknown>
+}
+
+export interface WorkspaceMutations {
+  /** Overrides the derived title; passing null restores it. */
+  setTitle(workspaceId: string, title: string | null): Promise<unknown>
+  /** Pins or unpins the workspace; the directory reorders on the subscription echo. */
+  setPinned(workspaceId: string, pinned: boolean): Promise<unknown>
+  /** Clears the attention state; the row settles on the subscription echo. */
+  clearAttention(workspaceId: string): Promise<void>
+  /** Applies or removes one label; reflected when the subscription echoes. */
+  toggleLabel(workspaceId: string, name: string, assigned: boolean): Promise<unknown>
+  /** Removes every applied label the descriptor currently carries. */
+  clearLabels(workspaceId: string, applied: readonly string[]): Promise<unknown>
+  /** Starts daemon-side archiving; the row shows its pending state until the echo. */
+  archive(workspaceId: string): Promise<unknown>
+}
+
+/** Binds the workspace mutations to one daemon client. */
+export function workspaceMutations(client: WorkspaceMutationsClient): WorkspaceMutations {
+  return {
+    setTitle: (workspaceId, title) => client.setWorkspaceTitle(workspaceId, title),
+    setPinned: (workspaceId, pinned) => client.setWorkspacePinned(workspaceId, pinned),
+    clearAttention: (workspaceId) => client.clearWorkspaceAttention(workspaceId),
+    toggleLabel: (workspaceId, name, assigned) => {
+      const trimmed = name.trim()
+      return client.setWorkspaceLabel({
+        workspaceId,
+        label: { name: trimmed, color: workspaceLabelColor(trimmed) },
+        assigned,
+      })
+    },
+    clearLabels: (workspaceId, applied) =>
+      Promise.all(applied.map((name) => client.setWorkspaceLabel({ workspaceId, label: { name, color: workspaceLabelColor(name) }, assigned: false }))),
+    archive: (workspaceId) => client.archiveWorkspace(workspaceId),
+  }
+}

--- a/agent-directory/workspace-shortcuts.test.ts
+++ b/agent-directory/workspace-shortcuts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { applyWorkspaceUpdate, initialWorkspaceStore, workspaceProjectGroups, workspaceStatusGroups, type WorkspaceStore } from './workspaces'
 import type { WorkspaceDescriptor } from '../daemon/paseo'
+import { workspace } from './test-support'
 import { EMPTY_FILTERS, type WorkspaceFilters } from './display-preferences'
 import {
   isJumpShortcut,
@@ -11,24 +12,6 @@ import {
   visibleWorkspaceIds,
   type WalkSection,
 } from './workspace-shortcuts'
-
-function workspace(over: Partial<WorkspaceDescriptor>): WorkspaceDescriptor {
-  return {
-    id: over.id ?? 'w1',
-    projectId: over.projectId ?? 'p1',
-    projectDisplayName: over.projectDisplayName ?? 'storefront',
-    projectRootPath: over.projectRootPath ?? '/home/me/dev/storefront',
-    projectKind: 'git',
-    workspaceKind: 'directory',
-    name: over.name ?? 'storefront',
-    archivingAt: null,
-    status: 'running',
-    statusEnteredAt: null,
-    activityAt: over.activityAt ?? '2026-08-24T10:00:00Z',
-    scripts: [],
-    ...over,
-  } as WorkspaceDescriptor
-}
 
 function storeWith(...descriptors: WorkspaceDescriptor[]): WorkspaceStore {
   let store: WorkspaceStore = initialWorkspaceStore

--- a/agent-directory/workspace-shortcuts.test.ts
+++ b/agent-directory/workspace-shortcuts.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from 'bun:test'
+import { applyWorkspaceUpdate, initialWorkspaceStore, workspaceProjectGroups, workspaceStatusGroups, type WorkspaceStore } from './workspaces'
+import type { WorkspaceDescriptor } from '../daemon/paseo'
+import { EMPTY_FILTERS, type WorkspaceFilters } from './display-preferences'
+import {
+  isJumpShortcut,
+  isNextWorkspace,
+  isPrevWorkspace,
+  moveWorkspace,
+  prevNextWorkspaceTarget,
+  visibleWorkspaceIds,
+  type WalkSection,
+} from './workspace-shortcuts'
+
+function workspace(over: Partial<WorkspaceDescriptor>): WorkspaceDescriptor {
+  return {
+    id: over.id ?? 'w1',
+    projectId: over.projectId ?? 'p1',
+    projectDisplayName: over.projectDisplayName ?? 'storefront',
+    projectRootPath: over.projectRootPath ?? '/home/me/dev/storefront',
+    projectKind: 'git',
+    workspaceKind: 'directory',
+    name: over.name ?? 'storefront',
+    archivingAt: null,
+    status: 'running',
+    statusEnteredAt: null,
+    activityAt: over.activityAt ?? '2026-08-24T10:00:00Z',
+    scripts: [],
+    ...over,
+  } as WorkspaceDescriptor
+}
+
+function storeWith(...descriptors: WorkspaceDescriptor[]): WorkspaceStore {
+  let store: WorkspaceStore = initialWorkspaceStore
+  for (const descriptor of descriptors) {
+    store = applyWorkspaceUpdate(store, { kind: 'upsert', workspace: descriptor })
+  }
+  return store
+}
+
+function section(key: string, ...rows: string[]): WalkSection {
+  return { key, name: key, workspaces: rows.map((id) => ({ id })) }
+}
+
+describe('visibleWorkspaceIds', () => {
+  test('walks sections in order, skipping collapsed ones', () => {
+    const sections = [section('p1', 'a', 'b'), section('p2', 'c'), section('p3', 'd', 'e')]
+    expect(visibleWorkspaceIds(sections, new Set())).toEqual(['a', 'b', 'c', 'd', 'e'])
+    expect(visibleWorkspaceIds(sections, new Set(['p2']))).toEqual(['a', 'b', 'd', 'e'])
+    expect(visibleWorkspaceIds(sections, new Set(['p1', 'p3']))).toEqual(['c'])
+    expect(visibleWorkspaceIds(sections, new Set(['p1', 'p2', 'p3']))).toEqual([])
+  })
+
+  test('collapsed keys that match no section are ignored', () => {
+    expect(visibleWorkspaceIds([section('a', 'x')], new Set(['nope']))).toEqual(['x'])
+  })
+
+  test('empty sections contribute nothing', () => {
+    expect(visibleWorkspaceIds([section('a'), section('b', 'x')], new Set())).toEqual(['x'])
+  })
+})
+
+describe('visibleWorkspaceIds over sidebar-shaped sections', () => {
+  const ws = storeWith(
+    workspace({ id: 'a', projectId: 'p1', status: 'running', activityAt: '2026-08-24T10:00:00Z' }),
+    workspace({ id: 'b', projectId: 'p1', status: 'failed', pinnedAt: '2026-08-24T09:00:00Z', activityAt: '2026-08-24T11:00:00Z' }),
+    workspace({ id: 'c', projectId: 'p2', status: 'done', activityAt: '2026-08-24T12:00:00Z' }),
+  )
+  const filters: WorkspaceFilters = EMPTY_FILTERS
+
+  // The Sidebar builds its sections the same way (project or status grouping),
+  // so these compose the group ordering + filters into the walk-order seam.
+  const projectSections = (store: WorkspaceStore, f: WorkspaceFilters): WalkSection[] =>
+    workspaceProjectGroups(store, false, f).map((group) => ({
+      key: group.projectId,
+      name: group.name,
+      workspaces: group.workspaces,
+    }))
+  const statusSections = (store: WorkspaceStore, f: WorkspaceFilters): WalkSection[] =>
+    workspaceStatusGroups(store, false, f).map((group) => ({
+      key: group.status,
+      name: group.label,
+      workspaces: group.workspaces,
+    }))
+
+  test('project grouping places pinned rows first within their section', () => {
+    // p2 (c, 12:00) is the most-active project so walks first; inside p1, b is
+    // pinned ahead of a.
+    expect(visibleWorkspaceIds(projectSections(ws, filters), new Set())).toEqual(['c', 'b', 'a'])
+  })
+
+  test('collapsing a project drops its rows from the walk order', () => {
+    expect(visibleWorkspaceIds(projectSections(ws, filters), new Set(['p1']))).toEqual(['c'])
+  })
+
+  test('status grouping orders by urgency', () => {
+    // failed(b) before running(a) before done(c).
+    expect(visibleWorkspaceIds(statusSections(ws, filters), new Set())).toEqual(['b', 'a', 'c'])
+  })
+
+  test('a collapsed status group drops its rows', () => {
+    // 'failed' bucket holds only b.
+    expect(visibleWorkspaceIds(statusSections(ws, filters), new Set(['failed']))).toEqual(['a', 'c'])
+  })
+
+  test('filters narrow the walk order in project mode from the sidebar inputs', () => {
+    const projectFilter: WorkspaceFilters = { hosts: [], projects: ['p2'], labels: [] }
+    expect(visibleWorkspaceIds(projectSections(ws, projectFilter), new Set())).toEqual(['c'])
+  })
+
+  test('all groups filtered out yields an empty order', () => {
+    const emptyFilter: WorkspaceFilters = { hosts: [], projects: ['nope'], labels: [] }
+    expect(visibleWorkspaceIds(projectSections(ws, emptyFilter), new Set())).toEqual([])
+  })
+})
+
+describe('jump shortcut predicate', () => {
+  const event = (overrides: {
+    key?: string
+    modifiers?: Partial<{ shift: boolean; ctrl: boolean; alt: boolean; cmd: boolean }>
+  }) => ({ eventType: 'keyDown', ...overrides })
+
+  test('matches ⌘1–9 and Ctrl+1–9', () => {
+    expect(isJumpShortcut(event({ key: '1', modifiers: { cmd: true } }))).toBe(1)
+    expect(isJumpShortcut(event({ key: '9', modifiers: { ctrl: true } }))).toBe(9)
+    expect(isJumpShortcut(event({ key: '5', modifiers: { cmd: true } }))).toBe(5)
+  })
+
+  test('rejects zero, letters, and digits beyond nine', () => {
+    expect(isJumpShortcut(event({ key: '0', modifiers: { cmd: true } }))).toBeNull()
+    expect(isJumpShortcut(event({ key: 'k', modifiers: { cmd: true } }))).toBeNull()
+  })
+
+  test('requires cmd or ctrl and forbids alt/show, alt, and combined mods', () => {
+    expect(isJumpShortcut(event({ key: '1' }))).toBeNull()
+    expect(isJumpShortcut(event({ key: '1', modifiers: { alt: true, cmd: true } }))).toBeNull()
+    expect(isJumpShortcut(event({ key: '1', modifiers: { shift: true, cmd: true } }))).toBeNull()
+  })
+})
+
+describe('prev/next workspace predicates', () => {
+  const event = (overrides: {
+    key?: string
+    modifiers?: Partial<{ shift: boolean; ctrl: boolean; alt: boolean; cmd: boolean }>
+  }) => ({ eventType: 'keyDown', ...overrides })
+
+  test('matches ⌘[ and Ctrl+[ for prev', () => {
+    expect(isPrevWorkspace(event({ key: '[', modifiers: { cmd: true } }))).toBe(true)
+    expect(isPrevWorkspace(event({ key: '[', modifiers: { ctrl: true } }))).toBe(true)
+  })
+
+  test('matches ⌘] and Ctrl+] for next', () => {
+    expect(isNextWorkspace(event({ key: ']', modifiers: { cmd: true } }))).toBe(true)
+    expect(isNextWorkspace(event({ key: ']', modifiers: { ctrl: true } }))).toBe(true)
+  })
+
+  test('requires the right key and forbids alt/shift', () => {
+    expect(isPrevWorkspace(event({ key: ']', modifiers: { cmd: true } }))).toBe(false)
+    expect(isNextWorkspace(event({ key: '[', modifiers: { cmd: true } }))).toBe(false)
+    expect(isPrevWorkspace(event({ key: '[', modifiers: { alt: true, cmd: true } }))).toBe(false)
+    expect(isPrevWorkspace(event({ key: '[', modifiers: { shift: true, cmd: true } }))).toBe(false)
+  })
+})
+
+describe('moveWorkspace', () => {
+  test('wraps around both ends', () => {
+    expect(moveWorkspace(0, 3, -1)).toBe(2)
+    expect(moveWorkspace(2, 3, 1)).toBe(0)
+    expect(moveWorkspace(1, 3, 1)).toBe(2)
+    expect(moveWorkspace(1, 3, -1)).toBe(0)
+  })
+
+  test('handles multi-step and empty lists', () => {
+    expect(moveWorkspace(0, 3, 4)).toBe(1)
+    expect(moveWorkspace(0, 0, 1)).toBe(-1)
+  })
+})
+
+describe('prevNextWorkspaceTarget', () => {
+  const order = ['a', 'b', 'c']
+
+  test('wraps at both ends from a current selection', () => {
+    expect(prevNextWorkspaceTarget(order, 'c', 1)).toBe(0)
+    expect(prevNextWorkspaceTarget(order, 'a', -1)).toBe(2)
+    expect(prevNextWorkspaceTarget(order, 'b', 1)).toBe(2)
+    expect(prevNextWorkspaceTarget(order, 'b', -1)).toBe(0)
+  })
+
+  test('no selection starts at the top forward and bottom backward', () => {
+    expect(prevNextWorkspaceTarget(order, null, 1)).toBe(0)
+    expect(prevNextWorkspaceTarget(order, null, -1)).toBe(2)
+  })
+
+  test('a selection filtered out of the visible order counts as no selection', () => {
+    expect(prevNextWorkspaceTarget(order, 'zz', 1)).toBe(0)
+    expect(prevNextWorkspaceTarget(order, 'zz', -1)).toBe(2)
+  })
+
+  test('nothing visible yields -1', () => {
+    expect(prevNextWorkspaceTarget([], null, 1)).toBe(-1)
+  })
+})

--- a/agent-directory/workspace-shortcuts.ts
+++ b/agent-directory/workspace-shortcuts.ts
@@ -1,0 +1,93 @@
+/**
+ * Workspace jump shortcuts: visible walk-order computation and pure key
+ * predicates. The walk-order function mirrors the Sidebar's render order —
+ * collapsed sections are skipped so the keyboard handler targets only rows the
+ * sidebar actually shows — and the key predicates and navigation math stay
+ * unit-testable without the runtime, mirroring palette.ts's own predicate.
+ */
+
+// ---- row model ---------------------------------------------------------------
+
+/** One section of the walk-order: matches SidebarGroup's shape. */
+export interface WalkSection {
+  key: string
+  name: string
+  /** Pre-sorted rows; collapsed sections have their rows skipped. */
+  workspaces: readonly { id: string }[]
+}
+
+// ---- pure walk-order ---------------------------------------------------------
+
+/**
+ * The visible workspace ids in walk order: one id per rendered row, sections in
+ * order, rows inside a section following the sidebar's own sort (pinned first,
+ * then by activity). Collapsed sections are skipped entirely. Pure over the
+ * section/row model, so every Sidebar input (grouping, filters, collapse) feeds
+ * in already-shaped by the caller.
+ */
+export function visibleWorkspaceIds(
+  sections: readonly WalkSection[],
+  collapsedProjects: ReadonlySet<string>,
+): string[] {
+  const ids: string[] = []
+  for (const section of sections) {
+    if (collapsedProjects.has(section.key)) continue
+    for (const row of section.workspaces) ids.push(row.id)
+  }
+  return ids
+}
+
+// ---- key predicates ----------------------------------------------------------
+
+export interface KeyEventLike {
+  key?: string
+  modifiers?: { cmd?: boolean; ctrl?: boolean; alt?: boolean; shift?: boolean }
+}
+
+/** Cmd/Ctrl + digit 1–9 without alt or shift. */
+export function isJumpShortcut(event: KeyEventLike): number | null {
+  if (event.modifiers?.alt || event.modifiers?.shift) return null
+  if (!(event.modifiers?.cmd || event.modifiers?.ctrl)) return null
+  const digit = parseInt(event.key ?? '', 10)
+  if (digit >= 1 && digit <= 9) return digit
+  return null
+}
+
+/** Cmd/Ctrl + [ (next = ], prev = [ ) without alt or shift. */
+export function isPrevWorkspace(event: KeyEventLike): boolean {
+  if (event.modifiers?.alt || event.modifiers?.shift) return false
+  if (!(event.modifiers?.cmd || event.modifiers?.ctrl)) return false
+  return event.key === '['
+}
+
+export function isNextWorkspace(event: KeyEventLike): boolean {
+  if (event.modifiers?.alt || event.modifiers?.shift) return false
+  if (!(event.modifiers?.cmd || event.modifiers?.ctrl)) return false
+  return event.key === ']'
+}
+
+// ---- navigation math ---------------------------------------------------------
+
+/** Circular delta over the walk order, reusing the palette's wrap formula. */
+export function moveWorkspace(currentIndex: number, count: number, delta: number): number {
+  if (count <= 0) return -1
+  return (((currentIndex + delta) % count) + count) % count
+}
+
+/**
+ * The walk-order target for a prev/next gesture given the current selection.
+ * With no selection (or a selection filtered out of the visible order), next
+ * lands at the top and prev at the bottom; otherwise it wraps circularly.
+ * Returns -1 only when nothing is visible.
+ */
+export function prevNextWorkspaceTarget(
+  order: readonly string[],
+  currentId: string | null,
+  delta: 1 | -1,
+): number {
+  const count = order.length
+  if (count <= 0) return -1
+  const index = order.indexOf(currentId ?? '')
+  if (index < 0) return delta < 0 ? count - 1 : 0
+  return moveWorkspace(index, count, delta)
+}

--- a/agent-directory/workspaces.test.ts
+++ b/agent-directory/workspaces.test.ts
@@ -14,6 +14,7 @@ import {
   workspaceDirectory,
   workspaceDisplayName,
   workspaceProjectGroups,
+  workspaceStatusGroups,
   type WorkspaceStore,
 } from './workspaces'
 import { relativeTimeAt, sortAgents, type AgentEntry, type EmptyProjectDescriptor, type WorkspaceDescriptor } from '../daemon/paseo'
@@ -345,6 +346,74 @@ describe('workspaceProjectGroups', () => {
       emptyProjects: [],
     }
     expect(workspaceProjectGroups(store, false)[0]!.name).toBe('Checkout Flow')
+  })
+})
+
+describe('workspaceStatusGroups', () => {
+  test('groups by status in urgency order, rows recency-sorted, empties omitted', () => {
+    const store: WorkspaceStore = {
+      workspaces: [
+        workspace({ id: 'a', status: 'done', activityAt: '2026-08-24T09:00:00Z' }),
+        workspace({ id: 'b', status: 'running', activityAt: '2026-08-24T11:00:00Z' }),
+        workspace({ id: 'c', status: 'needs_input', activityAt: '2026-08-24T10:00:00Z' }),
+        workspace({ id: 'd', status: 'running', activityAt: '2026-08-24T12:00:00Z' }),
+      ],
+      emptyProjects: [],
+    }
+    const groups = workspaceStatusGroups(store, false)
+    expect(groups.map((group) => group.status)).toEqual(['needs_input', 'running', 'done'])
+    const running = groups.find((group) => group.status === 'running')!
+    expect(running.label).toBe('Working')
+    expect(running.workspaces.map((w) => w.id)).toEqual(['d', 'b'])
+  })
+
+  test('status mode applies the same AND filters as project mode', () => {
+    const store: WorkspaceStore = {
+      workspaces: [
+        workspace({ id: 'keep', status: 'failed', projectId: 'p1', labels: ['bug'] }),
+        workspace({ id: 'drop', status: 'done', projectId: 'p9', labels: ['bug'] }),
+      ],
+      emptyProjects: [],
+    }
+    const groups = workspaceStatusGroups(store, false, { hosts: [], projects: ['p1'], labels: ['bug'] })
+    expect(groups.map((group) => group.status)).toEqual(['failed'])
+  })
+})
+
+describe('filtered project groups', () => {
+  test('an active project label filter hides non-matching workspaces and their projects', () => {
+    const store: WorkspaceStore = {
+      workspaces: [
+        workspace({ id: 'a', projectId: 'p1', projectDisplayName: 'keep', labels: ['bug'] }),
+        workspace({ id: 'b', projectId: 'p2', projectDisplayName: 'drop', labels: ['docs'] }),
+        workspace({ id: 'c', projectId: 'p1', projectDisplayName: 'keep', labels: ['docs'] }),
+      ],
+      emptyProjects: [],
+    }
+    const groups = workspaceProjectGroups(store, false, { hosts: [], projects: [], labels: ['bug'] })
+    expect(groups.map((group) => group.name)).toEqual(['keep'])
+    expect(groups[0]!.workspaces.map((w) => w.id)).toEqual(['a'])
+  })
+
+  test('daemon-truly-empty projects still render under an active filter', () => {
+    const store: WorkspaceStore = {
+      workspaces: [workspace({ id: 'a', projectId: 'p1', projectDisplayName: 'zeta', labels: ['bug'] })],
+      emptyProjects: [{ projectId: 'p-empty', projectDisplayName: 'alpha', projectRootPath: '/x', projectKind: 'git' }],
+    }
+    const groups = workspaceProjectGroups(store, false, { hosts: [], projects: [], labels: ['bug'] })
+    expect(groups.map((group) => group.name)).toEqual(['zeta', 'alpha'])
+  })
+
+  test('no filter matches everything, preserving the existing order', () => {
+    const store: WorkspaceStore = {
+      workspaces: [
+        workspace({ id: 'a', projectId: 'p1', projectDisplayName: 'zeta' }),
+        workspace({ id: 'b', projectId: 'p0', projectDisplayName: 'api', activityAt: '2026-08-24T11:00:00Z' }),
+      ],
+      emptyProjects: [],
+    }
+    const groups = workspaceProjectGroups(store, false, { hosts: [], projects: [], labels: [] })
+    expect(groups.map((group) => group.name)).toEqual(['api', 'zeta'])
   })
 })
 

--- a/agent-directory/workspaces.test.ts
+++ b/agent-directory/workspaces.test.ts
@@ -11,6 +11,7 @@ import {
   sortWorkspaces,
   visibleWorkspaces,
   workspaceBranchName,
+  workspaceCatalog,
   workspaceDirectoryChoices,
   workspaceDirectory,
   workspaceDisplayName,
@@ -20,24 +21,7 @@ import {
   type WorkspaceStore,
 } from './workspaces'
 import { relativeTimeAt, sortAgents, type AgentEntry, type EmptyProjectDescriptor, type WorkspaceDescriptor } from '../daemon/paseo'
-
-function workspace(over: Partial<WorkspaceDescriptor>): WorkspaceDescriptor {
-  return {
-    id: over.id ?? 'w1',
-    projectId: over.projectId ?? 'p1',
-    projectDisplayName: over.projectDisplayName ?? 'storefront',
-    projectRootPath: over.projectRootPath ?? '/home/me/dev/storefront',
-    projectKind: 'git',
-    workspaceKind: 'directory',
-    name: over.name ?? 'storefront',
-    archivingAt: null,
-    status: 'running',
-    statusEnteredAt: null,
-    activityAt: over.activityAt ?? '2026-08-24T10:00:00Z',
-    scripts: [],
-    ...over,
-  } as WorkspaceDescriptor
-}
+import { workspace } from './test-support'
 
 function emptyProject(over: Partial<EmptyProjectDescriptor>): EmptyProjectDescriptor {
   return {
@@ -48,6 +32,18 @@ function emptyProject(over: Partial<EmptyProjectDescriptor>): EmptyProjectDescri
     ...over,
   } as EmptyProjectDescriptor
 }
+
+const hostScript = (hostname: string) => ({
+  scriptName: 'dev',
+  type: 'script' as const,
+  hostname,
+  port: 3000,
+  proxyUrl: null,
+  lifecycle: 'running' as const,
+  health: 'healthy' as const,
+  exitCode: null,
+  terminalId: null,
+})
 
 const upsert = (descriptor: WorkspaceDescriptor) => ({ kind: 'upsert' as const, workspace: descriptor })
 
@@ -382,7 +378,7 @@ describe('workspaceStatusGroups', () => {
     const groups = workspaceStatusGroups(store, false)
     expect(groups.map((group) => group.status)).toEqual(['needs_input', 'running', 'done'])
     const running = groups.find((group) => group.status === 'running')!
-    expect(running.label).toBe('Working')
+    expect(running.label).toBe('Running')
     expect(running.workspaces.map((w) => w.id)).toEqual(['d', 'b'])
   })
 
@@ -433,6 +429,45 @@ describe('filtered project groups', () => {
     }
     const groups = workspaceProjectGroups(store, false, { hosts: [], projects: [], labels: [] })
     expect(groups.map((group) => group.name)).toEqual(['api', 'zeta'])
+  })
+})
+
+describe('workspaceCatalog', () => {
+  test('unions and sorts hosts and labels, and lists projects as grouped', () => {
+    const store: WorkspaceStore = {
+      workspaces: [
+        workspace({ id: 'a', projectId: 'p1', projectDisplayName: 'keep', labels: ['zeta', 'alpha'], scripts: [hostScript('devbox')] }),
+        workspace({ id: 'b', projectId: 'p2', projectDisplayName: 'api', labels: ['beta', 'alpha'], scripts: [hostScript('devbox')] }),
+        workspace({ id: 'c', projectId: 'p1', projectDisplayName: 'keep' }),
+      ],
+      emptyProjects: [],
+    }
+    const catalog = workspaceCatalog(store, false)
+    expect(catalog.hosts).toEqual(['devbox'])
+    expect(catalog.labels).toEqual(['alpha', 'beta', 'zeta'])
+    expect(catalog.projects.map((project) => project.id)).toEqual(['p1', 'p2'])
+  })
+
+  test('a split-host workspace contributes no host', () => {
+    const store: WorkspaceStore = {
+      workspaces: [workspace({ scripts: [hostScript('a'), hostScript('b')] })],
+      emptyProjects: [],
+    }
+    expect(workspaceCatalog(store, false).hosts).toEqual([])
+  })
+
+  test('archived workspaces stay out of the projects until revealed', () => {
+    const store: WorkspaceStore = {
+      workspaces: [workspace({ id: 'gone', archivingAt: '2026-08-24T09:00:00Z' })],
+      emptyProjects: [],
+    }
+    expect(workspaceCatalog(store, false).projects).toEqual([])
+    expect(workspaceCatalog(store, true).projects.map((project) => project.id)).toEqual(['p1'])
+  })
+
+  test('an empty store yields empty lists', () => {
+    const catalog = workspaceCatalog(initialWorkspaceStore, false)
+    expect(catalog).toEqual({ hosts: [], projects: [], labels: [] })
   })
 })
 

--- a/agent-directory/workspaces.test.ts
+++ b/agent-directory/workspaces.test.ts
@@ -10,9 +10,11 @@ import {
   projectName,
   sortWorkspaces,
   visibleWorkspaces,
+  workspaceBranchName,
   workspaceDirectoryChoices,
   workspaceDirectory,
   workspaceDisplayName,
+  workspaceLabels,
   workspaceProjectGroups,
   type WorkspaceStore,
 } from './workspaces'
@@ -168,6 +170,23 @@ describe('view-model mapping', () => {
   test('projectName prefers a custom project name', () => {
     expect(projectName(workspace({ projectCustomName: 'My Shop' }))).toBe('My Shop')
     expect(projectName(workspace({ projectCustomName: null }))).toBe('storefront')
+  })
+
+  test('branchName is the git runtime\'s current branch, or nothing', () => {
+    expect(workspaceBranchName(workspace({ gitRuntime: { currentBranch: ' feat/login ' } }))).toBe('feat/login')
+    expect(workspaceBranchName(workspace({ gitRuntime: { currentBranch: '   ' } }))).toBeNull()
+    expect(workspaceBranchName(workspace({ gitRuntime: null }))).toBeNull()
+    expect(workspaceBranchName(workspace({}))).toBeNull()
+  })
+
+  test('workspaceLabels unions and sorts label names across descriptors', () => {
+    const list = [
+      workspace({ id: 'a', labels: ['zeta', 'alpha'] }),
+      workspace({ id: 'b', labels: ['beta', 'alpha'] }),
+      workspace({ id: 'c' }),
+    ]
+    expect(workspaceLabels(list)).toEqual(['alpha', 'beta', 'zeta'])
+    expect(workspaceLabels([])).toEqual([])
   })
 
   test('archiving is one-way and visibility follows the reveal toggle', () => {

--- a/agent-directory/workspaces.test.ts
+++ b/agent-directory/workspaces.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  WORKSPACE_STATUS_URGENCY,
+  aggregateWorkspaceStatus,
   agentsOfWorkspace,
   applyWorkspaceUpdate,
   initialWorkspaceStore,
@@ -176,6 +178,108 @@ describe('view-model mapping', () => {
     expect(isArchivedWorkspace(list[1]!)).toBe(true)
     expect(visibleWorkspaces(list, false).map((w) => w.id)).toEqual(['live'])
     expect(visibleWorkspaces(list, true).map((w) => w.id)).toEqual(['live', 'gone'])
+  })
+})
+
+describe('aggregateWorkspaceStatus', () => {
+  // The ticket's ordering string names a "working" bucket, but the workspace
+  // descriptor's vocabulary is running | attention | needs_input | failed |
+  // done — the urgency order below is defined over that vocabulary alone.
+  test('the urgency order is the descriptor vocabulary, needs_input first', () => {
+    expect(WORKSPACE_STATUS_URGENCY).toEqual(['needs_input', 'failed', 'running', 'attention', 'done'])
+  })
+
+  test('a single workspace aggregates to its own status', () => {
+    expect(aggregateWorkspaceStatus([workspace({ status: 'attention' })])).toEqual({
+      status: 'attention',
+      count: 1,
+    })
+    expect(aggregateWorkspaceStatus([workspace({ status: 'done' })])).toEqual({ status: 'done', count: 1 })
+  })
+
+  test('an empty project aggregates to nothing', () => {
+    expect(aggregateWorkspaceStatus([])).toBeNull()
+  })
+
+  test('the most urgent bucket wins across mixed statuses', () => {
+    const mixed = [
+      workspace({ id: 'a', status: 'done' }),
+      workspace({ id: 'b', status: 'running' }),
+      workspace({ id: 'c', status: 'needs_input' }),
+      workspace({ id: 'd', status: 'attention' }),
+      workspace({ id: 'e', status: 'failed' }),
+    ]
+    expect(aggregateWorkspaceStatus(mixed)).toEqual({ status: 'needs_input', count: 1 })
+  })
+
+  test('each adjacent pair of the order resolves toward the more urgent', () => {
+    expect(aggregateWorkspaceStatus([
+      workspace({ id: 'a', status: 'failed' }),
+      workspace({ id: 'b', status: 'needs_input' }),
+    ])).toMatchObject({ status: 'needs_input' })
+    expect(aggregateWorkspaceStatus([
+      workspace({ id: 'a', status: 'running' }),
+      workspace({ id: 'b', status: 'failed' }),
+    ])).toMatchObject({ status: 'failed' })
+    expect(aggregateWorkspaceStatus([
+      workspace({ id: 'a', status: 'attention' }),
+      workspace({ id: 'b', status: 'running' }),
+    ])).toMatchObject({ status: 'running' })
+    expect(aggregateWorkspaceStatus([
+      workspace({ id: 'a', status: 'done' }),
+      workspace({ id: 'b', status: 'attention' }),
+    ])).toMatchObject({ status: 'attention' })
+  })
+
+  test('equally urgent workspaces resolve by count, not by picking one', () => {
+    const twoFailed = [
+      workspace({ id: 'a', status: 'failed' }),
+      workspace({ id: 'b', status: 'failed' }),
+      workspace({ id: 'c', status: 'done' }),
+      workspace({ id: 'd', status: 'done' }),
+    ]
+    expect(aggregateWorkspaceStatus(twoFailed)).toEqual({ status: 'failed', count: 2 })
+  })
+
+  test('the count covers only the winning bucket', () => {
+    const mixed = [
+      workspace({ id: 'a', status: 'needs_input' }),
+      workspace({ id: 'b', status: 'needs_input' }),
+      workspace({ id: 'c', status: 'running' }),
+      workspace({ id: 'd', status: 'running' }),
+      workspace({ id: 'e', status: 'running' }),
+    ]
+    expect(aggregateWorkspaceStatus(mixed)).toEqual({ status: 'needs_input', count: 2 })
+  })
+
+  test('a collapsed group aggregates over its visible members', () => {
+    const store: WorkspaceStore = {
+      workspaces: [
+        workspace({ id: 'store-a', projectId: 'p-store', status: 'done', activityAt: '2026-08-24T10:00:00Z' }),
+        workspace({ id: 'store-b', projectId: 'p-store', status: 'needs_input', activityAt: '2026-08-24T09:00:00Z' }),
+        workspace({
+          id: 'api-a',
+          projectId: 'p-api',
+          projectDisplayName: 'api',
+          projectRootPath: '/home/me/dev/api',
+          status: 'failed',
+        }),
+      ],
+      emptyProjects: [],
+    }
+    const groups = workspaceProjectGroups(store, false)
+    const storefront = groups.find((group) => group.projectId === 'p-store')!
+    expect(aggregateWorkspaceStatus(storefront.workspaces)).toEqual({ status: 'needs_input', count: 1 })
+    const api = groups.find((group) => group.projectId === 'p-api')!
+    expect(aggregateWorkspaceStatus(api.workspaces)).toEqual({ status: 'failed', count: 1 })
+  })
+
+  test('an emptied project has no members, so no pill', () => {
+    const groups = workspaceProjectGroups(
+      { workspaces: [], emptyProjects: [emptyProject({ projectId: 'p1' })] },
+      false,
+    )
+    expect(aggregateWorkspaceStatus(groups[0]!.workspaces)).toBeNull()
   })
 })
 

--- a/agent-directory/workspaces.ts
+++ b/agent-directory/workspaces.ts
@@ -118,6 +118,25 @@ export function workspaceDisplayName(descriptor: WorkspaceDescriptor): string {
   return descriptor.name
 }
 
+/** The branch a workspace sits on, or null when the daemon reports none. */
+export function workspaceBranchName(descriptor: WorkspaceDescriptor): string | null {
+  const branch = descriptor.gitRuntime?.currentBranch?.trim()
+  return branch || null
+}
+
+/**
+ * The union of label names across every given descriptor, sorted for a stable
+ * menu. The labels submenu lists this union; a descriptor's own applied labels
+ * are the ones rendered checked.
+ */
+export function workspaceLabels(descriptors: readonly WorkspaceDescriptor[]): string[] {
+  const labels = new Set<string>()
+  for (const descriptor of descriptors) {
+    for (const label of descriptor.labels ?? []) labels.add(label)
+  }
+  return [...labels].sort()
+}
+
 // ---- aggregate status pill -----------------------------------------------------
 //
 // A collapsed project reduces to one status pill summarizing its workspaces.

--- a/agent-directory/workspaces.ts
+++ b/agent-directory/workspaces.ts
@@ -118,6 +118,54 @@ export function workspaceDisplayName(descriptor: WorkspaceDescriptor): string {
   return descriptor.name
 }
 
+// ---- aggregate status pill -----------------------------------------------------
+//
+// A collapsed project reduces to one status pill summarizing its workspaces.
+// The roll-up is most-urgent-wins over the descriptor's own status vocabulary —
+// the protocol's `running | attention | needs_input | failed | done`, not the
+// agent directory's StatusBucket (`working`/`review` in daemon/paseo.ts is a
+// different vocabulary that must not leak in here).
+
+/**
+ * Most-urgent-wins order over the workspace descriptor's status vocabulary:
+ * workspaces demanding the user's hand first (needs_input), then breakage
+ * (failed), then live work (running), then flagged-but-alive (attention), then
+ * finished (done). Earlier entries win a collapsed project's pill. The order is
+ * a strict total order, so no two distinct statuses can tie; workspaces that
+ * share the winning bucket collapse into the pill's count.
+ */
+export const WORKSPACE_STATUS_URGENCY: readonly WorkspaceDescriptor['status'][] = [
+  'needs_input',
+  'failed',
+  'running',
+  'attention',
+  'done',
+]
+
+/** One collapsed project's pill: the most urgent bucket and how many workspaces sit in it. */
+export interface WorkspaceAggregateStatus {
+  status: WorkspaceDescriptor['status']
+  /** Workspaces sharing the winning bucket — the "affected" count the pill shows. */
+  count: number
+}
+
+/**
+ * The most-urgent-wins roll-up for a collapsed project: the earliest entry of
+ * WORKSPACE_STATUS_URGENCY present among the descriptors, with the number of
+ * workspaces in that bucket. Aggregates exactly the descriptors it is given —
+ * visibility filtering stays the caller's job (project groups already filter).
+ * An empty project aggregates to null: nothing to summarize, no pill.
+ */
+export function aggregateWorkspaceStatus(
+  descriptors: WorkspaceDescriptor[],
+): WorkspaceAggregateStatus | null {
+  for (const status of WORKSPACE_STATUS_URGENCY) {
+    const count = descriptors.filter((descriptor) => descriptor.status === status).length
+    if (count > 0) return { status, count }
+  }
+  return null
+}
+
 // ---- sidebar groups ----------------------------------------------------------
 
 /** One collapsible project group: zero or more workspace rows. */

--- a/agent-directory/workspaces.ts
+++ b/agent-directory/workspaces.ts
@@ -14,6 +14,7 @@ import {
   type WorkspaceDescriptor,
   type WorkspaceUpdate,
 } from '../daemon/paseo'
+import { EMPTY_FILTERS, type WorkspaceFilters, workspaceMatchesFilters } from './display-preferences'
 
 // ---- store -----------------------------------------------------------------
 
@@ -185,10 +186,19 @@ function groupActivity(group: WorkspaceProjectGroup): number | null {
  * Folds the store into collapsible project groups: each project with visible
  * workspaces, ordered by its most recent activity, then emptied projects in
  * name order so they still render. Rows inside a group stay recency-sorted.
+ *
+ * An active filter narrows which workspaces group; a project whose workspaces
+ * all fall to the filter simply does not appear (its rows are gone rather than
+ * misleadingly empty). Truly-empty projects from the daemon still render.
  */
-export function workspaceProjectGroups(store: WorkspaceStore, showArchived: boolean): WorkspaceProjectGroup[] {
+export function workspaceProjectGroups(
+  store: WorkspaceStore,
+  showArchived: boolean,
+  filters: WorkspaceFilters = EMPTY_FILTERS,
+): WorkspaceProjectGroup[] {
   const byProject = new Map<string, WorkspaceProjectGroup>()
   for (const descriptor of visibleWorkspaces(store.workspaces, showArchived)) {
+    if (!workspaceMatchesFilters(descriptor, filters)) continue
     let group = byProject.get(descriptor.projectId)
     if (!group) {
       group = {
@@ -220,6 +230,53 @@ export function workspaceProjectGroups(store: WorkspaceStore, showArchived: bool
     if (activityB != null) return 1
     return a.name.localeCompare(b.name)
   })
+  return groups
+}
+
+// ---- status grouping ----------------------------------------------------------
+//
+// Status group mode arranges the sidebar the way the agent directory's buckets
+// do — trouble first, then live work, then done — but over the workspace
+// descriptor's own status vocabulary (running | attention | needs_input |
+// failed | done), never the agent dialect (working/review) that must not leak
+// in here. The bucket order reuses WORKSPACE_STATUS_URGENCY.
+
+/** One status bucket group in status group mode. */
+export interface WorkspaceStatusGroup {
+  status: WorkspaceDescriptor['status']
+  label: string
+  workspaces: WorkspaceDescriptor[]
+}
+
+const WORKSPACE_STATUS_LABELS: Record<WorkspaceDescriptor['status'], string> = {
+  needs_input: 'Needs input',
+  failed: 'Failed',
+  running: 'Working',
+  attention: 'Attention',
+  done: 'Done',
+}
+
+/**
+ * Folds the visible, filter-matching workspaces into status groups in
+ * WORKSPACE_STATUS_URGENCY order, each recency-sorted; groups with nothing to
+ * show are omitted. A collapsed status group aggregates like a project's pill.
+ */
+export function workspaceStatusGroups(
+  store: WorkspaceStore,
+  showArchived: boolean,
+  filters: WorkspaceFilters = EMPTY_FILTERS,
+): WorkspaceStatusGroup[] {
+  const visible = visibleWorkspaces(store.workspaces, showArchived).filter((descriptor) =>
+    workspaceMatchesFilters(descriptor, filters),
+  )
+  const sorted = sortWorkspaces(visible)
+  const groups: WorkspaceStatusGroup[] = []
+  for (const status of WORKSPACE_STATUS_URGENCY) {
+    const workspaces = sorted.filter((descriptor) => descriptor.status === status)
+    if (workspaces.length > 0) {
+      groups.push({ status, label: WORKSPACE_STATUS_LABELS[status], workspaces })
+    }
+  }
   return groups
 }
 

--- a/agent-directory/workspaces.ts
+++ b/agent-directory/workspaces.ts
@@ -14,7 +14,7 @@ import {
   type WorkspaceDescriptor,
   type WorkspaceUpdate,
 } from '../daemon/paseo'
-import { EMPTY_FILTERS, type WorkspaceFilters, workspaceMatchesFilters } from './display-preferences'
+import { EMPTY_FILTERS, type WorkspaceFilters, workspaceHost, workspaceMatchesFilters } from './display-preferences'
 
 // ---- store -----------------------------------------------------------------
 
@@ -252,6 +252,39 @@ export function workspaceProjectGroups(
   return groups
 }
 
+/** The heading union a filter menu offers: every host, project, and label. */
+export interface WorkspaceCatalog {
+  hosts: string[]
+  projects: { id: string; name: string }[]
+  labels: string[]
+}
+
+/**
+ * The filterable catalog the view menu derives once from the store: the sorted
+ * union of hostnames and labels across every descriptor, plus the projects as
+ * the sidebar actually groups them (archived rows hidden unless revealed).
+ * This is the menu's source of truth, kept here so the sidebar's host/label
+ * union does not duplicate the labels logic that workspaceLabels already owns.
+ */
+export function workspaceCatalog(store: WorkspaceStore, showArchived: boolean): WorkspaceCatalog {
+  const hosts = new Set<string>()
+  const labels = new Set<string>()
+  for (const descriptor of store.workspaces) {
+    const host = workspaceHost(descriptor)
+    if (host) hosts.add(host)
+    for (const label of descriptor.labels ?? []) labels.add(label)
+  }
+  const projects = workspaceProjectGroups(store, showArchived).map((group) => ({
+    id: group.projectId,
+    name: group.name,
+  }))
+  return {
+    hosts: [...hosts].sort(),
+    projects,
+    labels: [...labels].sort(),
+  }
+}
+
 // ---- status grouping ----------------------------------------------------------
 //
 // Status group mode arranges the sidebar the way the agent directory's buckets
@@ -270,7 +303,7 @@ export interface WorkspaceStatusGroup {
 const WORKSPACE_STATUS_LABELS: Record<WorkspaceDescriptor['status'], string> = {
   needs_input: 'Needs input',
   failed: 'Failed',
-  running: 'Working',
+  running: 'Running',
   attention: 'Attention',
   done: 'Done',
 }

--- a/app-state.test.ts
+++ b/app-state.test.ts
@@ -9,6 +9,8 @@ import {
   memoryStorage,
   showArchivedAgents,
   showArchivedWorkspaces,
+  workspaceFilters,
+  workspaceMetaConfig,
 } from './app-state'
 
 describe('app-state store', () => {
@@ -47,6 +49,36 @@ describe('app-state store', () => {
     createAppStore(storage).set(directoryGrouping, 'project')
     const reopened = createAppStore(storage)
     expect(reopened.get(directoryGrouping)).toBe('project')
+  })
+
+  test('the meta config and filters persist and read back their full shape', () => {
+    const storage = memoryStorage()
+    const meta = {
+      slots: { branch: false, project: true, host: false, pullRequest: true, services: false, labels: true },
+      checksMode: 'iconOnly' as const,
+      trailing: 'activity' as const,
+      titleSource: 'branch' as const,
+    }
+    const filters = { hosts: ['devbox'], projects: ['p1'], labels: ['bug', '*unlabelled*'] }
+    const store = createAppStore(storage)
+    store.set(workspaceMetaConfig, meta)
+    store.set(workspaceFilters, filters)
+    const reopened = createAppStore(storage)
+    expect(reopened.get(workspaceMetaConfig)).toEqual(meta)
+    expect(reopened.get(workspaceFilters)).toEqual(filters)
+  })
+
+  test('a stale meta config or filter shape falls back to defaults', () => {
+    const stale = {
+      readAll: () => ({
+        'workspace.meta': { slots: { branch: 'yes' }, checksMode: 'weird', trailing: 'diffStat', titleSource: 'title' },
+        'workspace.filters': { hosts: 'devbox', projects: {}, labels: [1] },
+      }),
+      writeAll: () => {},
+    }
+    const store = createAppStore(stale)
+    expect(store.get(workspaceMetaConfig)).toEqual(workspaceMetaConfig.fallback)
+    expect(store.get(workspaceFilters)).toEqual(workspaceFilters.fallback)
   })
 })
 

--- a/app-state.test.ts
+++ b/app-state.test.ts
@@ -11,7 +11,9 @@ import {
   showArchivedWorkspaces,
   workspaceFilters,
   workspaceMetaConfig,
+  workspacePanes,
 } from './app-state'
+import type { PaneLayout } from './layout/layout'
 
 describe('app-state store', () => {
   test('first run yields defaults when nothing is stored', () => {
@@ -79,6 +81,123 @@ describe('app-state store', () => {
     const store = createAppStore(stale)
     expect(store.get(workspaceMetaConfig)).toEqual(workspaceMetaConfig.fallback)
     expect(store.get(workspaceFilters)).toEqual(workspaceFilters.fallback)
+  })
+})
+
+describe('pane layout persistence', () => {
+  const wsKey = (host: string, ws: string) => `${host}::${ws}`
+
+  test('defaults to an empty map on first run', () => {
+    const store = createAppStore(memoryStorage())
+    expect(store.get(workspacePanes)).toEqual({})
+  })
+
+  test('a pane layout persists and reads back its full shape', () => {
+    const storage = memoryStorage()
+    const layout: PaneLayout = {
+      root: {
+        kind: 'group',
+        id: 'g0',
+        direction: 'horizontal',
+        children: [
+          { kind: 'leaf', id: 'p0', tabIds: ['t0', 't1'], focusedTabId: 't1' },
+          { kind: 'leaf', id: 'p1', tabIds: ['t2'], focusedTabId: 't2' },
+        ],
+        sizes: [0.6, 0.4],
+      },
+      activePaneId: 'p1',
+    }
+    const store = createAppStore(storage)
+    store.set(workspacePanes, { [wsKey('devbox', 'ws1')]: layout })
+    const reopened = createAppStore(storage)
+    expect(reopened.get(workspacePanes)).toEqual({ [wsKey('devbox', 'ws1')]: layout })
+  })
+
+  test('layouts keyed by host+workspace are stored independently', () => {
+    const storage = memoryStorage()
+    const store = createAppStore(storage)
+    const a: PaneLayout = { root: { kind: 'leaf', id: 'p0', tabIds: ['t0'], focusedTabId: 't0' }, activePaneId: 'p0' }
+    const b: PaneLayout = {
+      root: {
+        kind: 'group',
+        id: 'g0',
+        direction: 'vertical',
+        children: [
+          { kind: 'leaf', id: 'p0', tabIds: ['t5'], focusedTabId: 't5' },
+          { kind: 'leaf', id: 'p1', tabIds: ['t6'], focusedTabId: 't6' },
+        ],
+        sizes: [0.5, 0.5],
+      },
+      activePaneId: 'p1',
+    }
+    store.set(workspacePanes, {
+      [wsKey('devbox', 'ws1')]: a,
+      [wsKey('devbox', 'ws2')]: b,
+      [wsKey('prod', 'ws1')]: b,
+    })
+    const reopened = createAppStore(storage)
+    const map = reopened.get(workspacePanes)
+    expect(map[wsKey('devbox', 'ws1')]).toEqual(a)
+    expect(map[wsKey('devbox', 'ws2')]).toEqual(b)
+    expect(map[wsKey('prod', 'ws1')]).toEqual(b)
+  })
+
+  test('a stale or malformed layout falls back to the empty map', () => {
+    const stale = {
+      readAll: () => ({
+        'layout.panes': {
+          'devbox::ws1': { root: { kind: 'leaf', id: 'p0', tabIds: [1], focusedTabId: 't0' }, activePaneId: 'nope' },
+        },
+      }),
+      writeAll: () => {},
+    }
+    const store = createAppStore(stale)
+    expect(store.get(workspacePanes)).toEqual({})
+  })
+
+  test('a group is rejected when its sizes do not match its children', () => {
+    const stale = {
+      readAll: () => ({
+        'layout.panes': {
+          'devbox::ws1': {
+            root: {
+              kind: 'group',
+              id: 'g0',
+              direction: 'horizontal',
+              children: [
+                { kind: 'leaf', id: 'p0', tabIds: [], focusedTabId: null },
+                { kind: 'leaf', id: 'p1', tabIds: [], focusedTabId: null },
+              ],
+              sizes: [0.5],
+            },
+            activePaneId: 'p0',
+          },
+        },
+      }),
+      writeAll: () => {},
+    }
+    const store = createAppStore(stale)
+    expect(store.get(workspacePanes)).toEqual({})
+  })
+
+  test('persisted layouts survive a restart over a shared in-memory storage', () => {
+    const storage = memoryStorage()
+    const layout: PaneLayout = {
+      root: {
+        kind: 'group',
+        id: 'g0',
+        direction: 'horizontal',
+        children: [
+          { kind: 'leaf', id: 'p0', tabIds: ['t0'], focusedTabId: 't0' },
+          { kind: 'leaf', id: 'p1', tabIds: ['t1'], focusedTabId: 't1' },
+        ],
+        sizes: [0.5, 0.5],
+      },
+      activePaneId: 'p0',
+    }
+    createAppStore(storage).set(workspacePanes, { [wsKey('devbox', 'ws1')]: layout })
+    const reopened = createAppStore(storage)
+    expect(reopened.get(workspacePanes)[wsKey('devbox', 'ws1')]).toEqual(layout)
   })
 })
 

--- a/app-state.ts
+++ b/app-state.ts
@@ -13,6 +13,8 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { useEffect, useState } from 'react'
+import { DEFAULT_META_CONFIG, type WorkspaceMetaConfig } from './agent-directory/workspace-meta'
+import { EMPTY_FILTERS, type WorkspaceFilters } from './agent-directory/display-preferences'
 
 export interface StateKey<T> {
   /** Stable name in storage; change it when the value's shape changes. */
@@ -138,6 +140,72 @@ export const showArchivedAgents: StateKey<boolean> = {
   name: 'directory.showArchivedAgents',
   fallback: false,
   validate: (raw) => (typeof raw === 'boolean' ? raw : undefined),
+}
+
+// ---- workspace display preferences ------------------------------------------
+
+const META_SLOT_KINDS = ['branch', 'project', 'host', 'pullRequest', 'services', 'labels'] as const
+const CHECKS_MODES = ['iconText', 'iconOnly', 'hidden'] as const
+const TRAILING_SLOTS = ['diffStat', 'activity'] as const
+const TITLE_SOURCES = ['title', 'branch'] as const
+
+function isBooleanMap(raw: unknown, keys: readonly string[]): raw is Record<string, boolean> {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return false
+  const record = raw as Record<string, unknown>
+  return keys.every((key) => typeof record[key] === 'boolean')
+}
+
+function stringArray(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  return raw.every((item) => typeof item === 'string') ? (raw as string[]) : undefined
+}
+
+/**
+ * The whole meta-line configuration — slot toggles, checks mode, trailing
+ * slot, title source — persisted as one value whose shape all live alongside
+ * the module default. Change the shape and the name must change too.
+ */
+export const workspaceMetaConfig: StateKey<WorkspaceMetaConfig> = {
+  name: 'workspace.meta',
+  fallback: DEFAULT_META_CONFIG,
+  validate: (raw) => {
+    if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+    const value = raw as Record<string, unknown>
+    const slots = value.slots
+    if (!isBooleanMap(slots, META_SLOT_KINDS)) return undefined
+    const checks = CHECKS_MODES.find((mode) => mode === value.checksMode)
+    const trailing = TRAILING_SLOTS.find((mode) => mode === value.trailing)
+    const titleSource = TITLE_SOURCES.find((mode) => mode === value.titleSource)
+    if (!checks || !trailing || !titleSource) return undefined
+    return {
+      slots: {
+        branch: slots.branch,
+        project: slots.project,
+        host: slots.host,
+        pullRequest: slots.pullRequest,
+        services: slots.services,
+        labels: slots.labels,
+      },
+      checksMode: checks,
+      trailing,
+      titleSource,
+    }
+  },
+}
+
+/** The sidebar's active filters; an empty-list dimension means no filtering. */
+export const workspaceFilters: StateKey<WorkspaceFilters> = {
+  name: 'workspace.filters',
+  fallback: EMPTY_FILTERS,
+  validate: (raw) => {
+    if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+    const value = raw as Record<string, unknown>
+    const hosts = stringArray(value.hosts)
+    const projects = stringArray(value.projects)
+    const labels = stringArray(value.labels)
+    if (!hosts || !projects || !labels) return undefined
+    return { hosts, projects, labels }
+  },
 }
 
 // ---- React adapter ----------------------------------------------------------

--- a/app-state.ts
+++ b/app-state.ts
@@ -15,6 +15,7 @@ import path from 'node:path'
 import { useEffect, useState } from 'react'
 import { DEFAULT_META_CONFIG, type WorkspaceMetaConfig } from './agent-directory/workspace-meta'
 import { EMPTY_FILTERS, type WorkspaceFilters } from './agent-directory/display-preferences'
+import { validatePaneLayout, type PaneLayout } from './layout/layout'
 
 export interface StateKey<T> {
   /** Stable name in storage; change it when the value's shape changes. */
@@ -205,6 +206,31 @@ export const workspaceFilters: StateKey<WorkspaceFilters> = {
     const labels = stringArray(value.labels)
     if (!hosts || !projects || !labels) return undefined
     return { hosts, projects, labels }
+  },
+}
+
+// ---- pane layouts -----------------------------------------------------------
+
+/**
+ * Persisted pane-tree layout per host+workspace. The value is a map keyed by
+ * `${host}::${workspaceId}` to a non-null PaneLayout (the default single-pane
+ * layout is never persisted). Deep-validated and JSON-roundtrip-safe (plain
+ * objects/arrays/strings/numbers — no Maps or Sets). Change the key name if
+ * the layout shape ever changes.
+ */
+export const workspacePanes: StateKey<Record<string, PaneLayout>> = {
+  name: 'layout.panes',
+  fallback: {},
+  validate: (raw) => {
+    if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+    const record = raw as Record<string, unknown>
+    const out: Record<string, PaneLayout> = {}
+    for (const [key, value] of Object.entries(record)) {
+      const parsed = validatePaneLayout(value)
+      if (!parsed) return undefined // any stale entry poisons the whole map
+      out[key] = parsed
+    }
+    return out
   },
 }
 

--- a/assets/icons/git-pull-request.svg
+++ b/assets/icons/git-pull-request.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" x2="6" y1="9" y2="21"/><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/></svg>

--- a/assets/icons/tag.svg
+++ b/assets/icons/tag.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"/><circle cx="7.5" cy="7.5" r="1"/></svg>

--- a/chat.tsx
+++ b/chat.tsx
@@ -68,7 +68,16 @@ import {
   type PastePayload,
 } from './composer/attachments'
 import { C, CONTENT_MAX_WIDTH, SIDEBAR_WIDTH } from './chrome/theme'
-import { Sidebar, Header, CenterMessage, agentStatusColor, daemonHost, type RowActionRef, type RowActionVerb } from './chrome/chrome'
+import { workspaceMutations } from './agent-directory/workspace-mutations'
+import {
+  Sidebar,
+  Header,
+  CenterMessage,
+  agentStatusColor,
+  daemonHost,
+  type RowActionRef,
+  type RowActionVerb,
+} from './chrome/chrome'
 import { Transcript } from './conversation/transcript'
 import { FeatureToggles, ModelPicker, OptionPicker, modeOptions, thinkingOptions } from './composer/pickers'
 import { Composer, ConfigNotice, FooterBar, TracksRow } from './composer/composer'
@@ -359,6 +368,29 @@ export function ChatApp() {
   const archiveWorkspaceRow = (id: string) => runRowAction('archive', id, () => daemon.archiveWorkspace(id))
   const renameWorkspaceRow = (id: string, name: string) =>
     runRowAction('rename', id, () => daemon.setWorkspaceTitle(id, name))
+  // The pin/labels/mark-as-read mutations go through the wrapper: labels earn
+  // their keep shaping the label+colour payload, the rest ride along for one
+  // narrow client seam instead of five ad-hoc daemon call sites.
+  const mutations = workspaceMutations(daemon)
+  const pinWorkspaceRow = (id: string, pinned: boolean) =>
+    runRowAction('pin', id, () => mutations.setPinned(id, pinned))
+  const markWorkspaceRead = (id: string) =>
+    runRowAction('mark-read', id, () => mutations.clearAttention(id))
+  const toggleWorkspaceLabel = (id: string, name: string, applied: boolean) =>
+    runRowAction('labels', id, () => mutations.toggleLabel(id, name, applied))
+  const clearWorkspaceLabels = (id: string) => {
+    const descriptor = workspaces.workspaces.find((candidate) => candidate.id === id)
+    const applied = descriptor?.labels ?? []
+    if (applied.length === 0) return
+    runRowAction('labels', id, () => mutations.clearLabels(id, applied))
+  }
+  // Copy is a synchronous clipboard write, not a daemon call; it needs no
+  // in-flight row and the menu computes its value from the descriptor it owns.
+  const copyWorkspaceValue = (value: string) => {
+    const clipboard = (navigator as { clipboard?: { writeText?: (text: string) => Promise<void> } }).clipboard
+    if (!clipboard?.writeText) return
+    clipboard.writeText(value).catch(() => {})
+  }
 
   // Agent lifecycle (archive, delete, rename): the promises drive the
   // in-flight disabling; the directory itself is only ever written by the
@@ -955,6 +987,11 @@ const listRef = useRef<{ id: number } | null>(null)
           busyRows={busyRows}
           onArchive={archiveWorkspaceRow}
           onRename={renameWorkspaceRow}
+          onCopy={copyWorkspaceValue}
+          onMarkRead={markWorkspaceRead}
+          onPin={pinWorkspaceRow}
+          onToggleLabel={toggleWorkspaceLabel}
+          onClearLabels={clearWorkspaceLabels}
           appStore={store}
           navState={navState}
           onNavBack={() => nav(-1)}

--- a/chat.tsx
+++ b/chat.tsx
@@ -125,12 +125,15 @@ import {
   reduceTabs,
   selectActiveAgentId,
   selectActiveDraft,
+  selectActiveSetup,
   selectActiveTab,
   selectTabs,
   type TabsEvent,
 } from './tabs/tabs'
 import { TabStrip } from './tabs/tab-strip'
 import { AgentTabPanel, type TabConversation } from './tabs/agent-tab-panel'
+import { SetupTabPanel } from './tabs/setup-tab-panel'
+import { setupSucceeded, useWorkspaceSetup } from './tabs/setup'
 
 // ---- daemon hooks ----------------------------------------------------------
 
@@ -287,6 +290,11 @@ export function ChatApp() {
     for (const entry of agents) everShownAgentIds.current.add(entry.id)
   }, [agents])
 
+  // Worktree-created agents awaiting their workspace id. A setup tab is keyed by
+  // workspace, which the daemon only reveals once the worktree exists; these ids
+  // bridge the gap from the create handle to the agent's directory entry.
+  const pendingSetupAgents = useRef<Set<string>>(new Set())
+
   // Workspace tabs: the strip of open agent + draft tabs with a focused one.
   // The reducer owns every add/close/select decision; this component only
   // translates gestures and daemon results into TabsEvents. `activeId` stays
@@ -299,6 +307,7 @@ export function ChatApp() {
   const activeTabId = tabsState.activeTabId
   const activeAgentId = selectActiveAgentId(tabsState)
   const activeDraft = selectActiveDraft(tabsState)
+  const activeSetup = selectActiveSetup(tabsState)
   const activeId = activeAgentId
   // Visited-agent history behind the chrome's back/forward arrows: opening an
   // agent records the visit, back/forward only move the cursor. An explicit
@@ -390,6 +399,11 @@ export function ChatApp() {
   const activeRepoKey = activeStatus ? repoKeyOf(activeStatus) : (activeEntry?.cwd ?? null)
   const activeQueue = activeRepoKey ? repoActions.state.repos[activeRepoKey] : undefined
 
+  // Workspace setup progress spine: a setup tab shows a worktree's bootstrap
+  // commands as they run; `useWorkspaceSetup` owns the per-workspace store.
+  const setup = useWorkspaceSetup(daemon)
+  const setupEntries = setup.state.entries
+
   // An agent that vanished from the directory (deleted) can no longer host a
   // conversation — Paseo's own client redirects away in both cases. Its tab is
   // closed, which lands on the neighbor (or the empty new-task state).
@@ -400,6 +414,34 @@ export function ChatApp() {
   useEffect(() => {
     if (activeEntryGone && activeTab) dispatchTabs({ type: 'close', tabId: activeTab.id })
   }, [activeEntryGone, activeTab])
+
+  // Worktree creation opens a setup tab once the daemon reveals the new
+  // workspace id on the agent's directory entry (the create handle carries no
+  // workspace yet). Non-worktree agents are never added here, so they never get
+  // a setup tab.
+  useEffect(() => {
+    if (pendingSetupAgents.current.size === 0) return
+    for (const agentId of pendingSetupAgents.current) {
+      const entry = agents.find((candidate) => candidate.id === agentId)
+      if (entry?.workspaceId) {
+        pendingSetupAgents.current.delete(agentId)
+        dispatchTabs({ type: 'openSetup', workspaceId: entry.workspaceId, agentId, createdAt: Date.now() })
+      }
+    }
+  }, [agents])
+
+  // A watched setup tab hands off to its agent's conversation the moment the
+  // daemon reports the worktree ready: the conversation takes over and the
+  // setup tab stays behind, collapsed to its summary chip.
+  useEffect(() => {
+    for (const tab of tabs) {
+      if (tab.target !== 'setup' || tab.id !== activeTabId) continue
+      const snapshot = setupEntries[tab.state.workspaceId]
+      if (setupSucceeded(snapshot)) {
+        dispatchTabs({ type: 'openAgent', agentId: tab.state.agentId, createdAt: tab.createdAt })
+      }
+    }
+  }, [tabs, activeTabId, setupEntries])
 
   // Row lifecycle actions disable per row while their daemon call is in flight;
   // directory truth arrives through the subscription, never from these results.
@@ -688,6 +730,10 @@ export function ChatApp() {
       })
       setPendingSeed({ agentId: handle.id, text, images: stagedImages })
       setVisitHistory((prev) => visitAgent(prev, handle.id))
+      // A worktree bootstrap needs a setup tab; its workspace id only appears
+      // on the agent's directory entry as the daemon creates the worktree, so
+      // it is resolved by the correlation effect above.
+      if (createWorktree === 'worktree') pendingSetupAgents.current.add(handle.id)
       if (activeTab && activeDraft) {
         // The draft tab flips into the new agent's tab and stays focused.
         dispatchTabs({
@@ -1110,12 +1156,25 @@ export function ChatApp() {
                 return entry ? displayName(entry) : 'Agent'
               }
               if (tab.target === 'draft') return basename(tab.state.cwd)
+              if (tab.target === 'setup') {
+                const snap = setupEntries[tab.state.workspaceId]
+                return snap ? `${snap.detail.branchName} setup` : 'Setup'
+              }
               return 'Workspace setup'
             }}
             dotColorFor={(tab) => {
-              if (tab.target !== 'agent') return null
-              const entry = agents.find((candidate) => candidate.id === tab.state.agentId)
-              return entry ? agentStatusColor(entry) : null
+              if (tab.target === 'agent') {
+                const entry = agents.find((candidate) => candidate.id === tab.state.agentId)
+                return entry ? agentStatusColor(entry) : null
+              }
+              if (tab.target === 'setup') {
+                const snap = setupEntries[tab.state.workspaceId]
+                if (snap?.status === 'running') return C.running
+                if (snap?.status === 'completed') return C.success
+                if (snap?.status === 'failed') return C.danger
+                return C.running
+              }
+              return null
             }}
             attentionFor={(tab) => {
               if (tab.target !== 'agent') return false
@@ -1156,7 +1215,7 @@ export function ChatApp() {
               onJumpToTurn={subagentFollow.jumpToTurn}
             />
           </div>
-        ) : activeId == null ? (
+        ) : activeId == null && !activeSetup ? (
           <CenterMessage
             title={activeDraft ? 'New draft' : 'New task'}
             detail={`Pick a model, then describe what to build in ${basename(activeDraft?.cwd ?? cwd)}.`}
@@ -1182,6 +1241,14 @@ export function ChatApp() {
               onEditQueued={editQueued}
               onOpenFile={openFile}
               workspaceRoot={agents.find((a) => a.id === tab.state.agentId)?.cwd ?? null}
+            />
+          ) : tab.target === 'setup' ? (
+            <SetupTabPanel
+              key={tab.id}
+              workspaceId={tab.state.workspaceId}
+              snapshot={setupEntries[tab.state.workspaceId] ?? null}
+              refresh={setup.refresh}
+              hidden={tab.id !== activeTabId}
             />
           ) : null,
         )}

--- a/chat.tsx
+++ b/chat.tsx
@@ -519,7 +519,7 @@ export function ChatApp() {
   // narrow client seam instead of five ad-hoc daemon call sites.
   const mutations = workspaceMutations(daemon)
   const pinWorkspaceRow = (id: string, pinned: boolean) =>
-    runRowAction('pin', id, () => mutations.setPinned(id, pinned))
+    runRowAction(pinned ? 'pin' : 'unpin', id, () => mutations.setPinned(id, pinned))
   const markWorkspaceRead = (id: string) =>
     runRowAction('mark-read', id, () => mutations.clearAttention(id))
   const toggleWorkspaceLabel = (id: string, name: string, applied: boolean) =>

--- a/chat.tsx
+++ b/chat.tsx
@@ -11,7 +11,7 @@
  * Remote daemon:   PASEO_URL=wss://host/ws PASEO_PASSWORD=... bun --hot chat.tsx
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { motion, render, useGpuix } from '@gpuix/react'
 import type { PaseoAgentConfig, PaseoClient } from '@getpaseo/client'
 import type { DaemonClient } from '@getpaseo/client/internal/daemon-client'
@@ -48,6 +48,12 @@ import {
   workspaceDirectory,
   type WorkspaceStore,
 } from './agent-directory/workspaces'
+import {
+  isJumpShortcut,
+  isNextWorkspace,
+  isPrevWorkspace,
+  prevNextWorkspaceTarget,
+} from './agent-directory/workspace-shortcuts'
 import {
   canGoBack,
   canGoForward,
@@ -340,6 +346,12 @@ export function ChatApp() {
   useWindowEvent((event) => {
     if (event.eventType === 'keyDown' && isPaletteToggle(event)) setPaletteOpen((open) => !open)
   })
+  // The sidebar reports its rendered rows up so the jump/prev/next shortcuts can
+  // target exactly those rows. A ref keeps the handle stable for the listener.
+  const visibleRowsRef = useRef<string[]>([])
+  const onVisibleRowsChange = useCallback((ids: string[]) => {
+    visibleRowsRef.current = ids
+  }, [])
 
   const {
     config: draftConfig,
@@ -471,6 +483,26 @@ export function ChatApp() {
       now: Date.now(),
     })
   }
+  // Jump + prev/next shortcuts over the sidebar's visible rows. The walk order
+  // arrives via visibleRowsRef (reported by the Sidebar itself); opening the
+  // target reuses onSelect's own path so a shortcut behaves like a row click.
+  useWindowEvent((event) => {
+    if (event.eventType !== 'keyDown') return
+    const orders = visibleRowsRef.current
+    // ⌘/Ctrl+1–9 jumps to the nth visible row; gaps from filtering and
+    // collapsed groups were already skipped by the walk-order computation.
+    const jump = isJumpShortcut(event)
+    if (jump != null) {
+      const target = orders[jump - 1]
+      if (target) openWorkspace(target)
+      return
+    }
+    if (isPrevWorkspace(event) || isNextWorkspace(event)) {
+      const index = prevNextWorkspaceTarget(orders, selectedWorkspaceId, isPrevWorkspace(event) ? -1 : 1)
+      const target = index >= 0 ? orders[index] : null
+      if (target) openWorkspace(target)
+    }
+  })
 
   // The composer's stop control: enabled only while the open agent runs. From
   // click until the cancellation is confirmed — the agent leaving running via
@@ -1044,6 +1076,7 @@ export function ChatApp() {
           navState={navState}
           onNavBack={() => nav(-1)}
           onNavForward={() => nav(1)}
+          onVisibleRowsChange={onVisibleRowsChange}
         />
         <div style={{ width: 1, height: '100%', flexShrink: 0, backgroundColor: C.sidebarBorder }} />
       </motion.div>

--- a/chat.tsx
+++ b/chat.tsx
@@ -119,18 +119,24 @@ import {
   SubagentViewerBar,
   type OpenSubagent,
 } from './tracks/tracks-panel'
-import { createAppStore, defaultStatePath, fileStateStorage, showArchivedAgents, useAppState } from './app-state'
+import { createAppStore, defaultStatePath, fileStateStorage, showArchivedAgents, workspacePanes, useAppState } from './app-state'
 import {
   initialTabs,
   reduceTabs,
-  selectActiveAgentId,
-  selectActiveDraft,
-  selectActiveTab,
   selectTabs,
   type TabsEvent,
 } from './tabs/tabs'
 import { TabStrip } from './tabs/tab-strip'
 import { AgentTabPanel, type TabConversation } from './tabs/agent-tab-panel'
+import { PaneSplit, type PaneStripMeta } from './tabs/pane-view'
+import {
+  activePaneTabId,
+  paneLeaves,
+  paneTabIds,
+  reduceLayout,
+  type PaneEvent,
+  type PaneLayoutState,
+} from './layout/layout'
 
 // ---- daemon hooks ----------------------------------------------------------
 
@@ -295,10 +301,37 @@ export function ChatApp() {
   const [tabsState, setTabsState] = useState(initialTabs)
   const dispatchTabs = (event: TabsEvent) => setTabsState((prev) => reduceTabs(prev, event))
   const tabs = selectTabs(tabsState)
-  const activeTab = selectActiveTab(tabsState)
-  const activeTabId = tabsState.activeTabId
-  const activeAgentId = selectActiveAgentId(tabsState)
-  const activeDraft = selectActiveDraft(tabsState)
+  // Pane layout: null = the single-pane default (non-persisted); a split tree
+  // otherwise. The tree references the same tabIds the #46 reducer owns.
+  const [layoutState, setLayoutState] = useState<PaneLayoutState>(null)
+  const layoutRef = useRef<PaneLayoutState>(null)
+  // Per host+workspace key for persistence; null at the directory new-task.
+  const layoutKey = selectedWorkspaceId ? `${daemonHost()}::${selectedWorkspaceId}` : null
+  /** Persists a layout change for the current workspace; null removes the entry. */
+  const persistLayout = (next: PaneLayoutState) => {
+    layoutRef.current = next
+    if (!layoutKey) return
+    const all = store.get(workspacePanes)
+    if (next) {
+      store.set(workspacePanes, { ...all, [layoutKey]: next })
+    } else {
+      const rest = { ...all }
+      delete rest[layoutKey]
+      store.set(workspacePanes, rest)
+    }
+  }
+  /** Translates a pane gesture into state and persistence together. */
+  const dispatchPane = (event: PaneEvent) => {
+    const next = reduceLayout(layoutRef.current, event)
+    setLayoutState(next)
+    persistLayout(next)
+  }
+  // The active tab that drives the header/composer: the active pane's focused
+  // tab when split, else the #46 workspace's focused tab.
+  const activeTabId = layoutState ? activePaneTabId(layoutState) : tabsState.activeTabId
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? null
+  const activeAgentId = activeTab && activeTab.target === 'agent' ? activeTab.state.agentId : null
+  const activeDraft = activeTab && activeTab.target === 'draft' ? activeTab.state : null
   const activeId = activeAgentId
   // Visited-agent history behind the chrome's back/forward arrows: opening an
   // agent records the visit, back/forward only move the cursor. An explicit
@@ -308,7 +341,13 @@ export function ChatApp() {
   /** Opens (or focuses) an agent's tab; recency seeds its strip position. */
   const openAgentTab = (id: string) => {
     const entry = agents.find((candidate) => candidate.id === id) ?? null
-    dispatchTabs({ type: 'openAgent', agentId: id, createdAt: entry ? activityAt(entry) : 0 })
+    const next = reduceTabs(tabsState, { type: 'openAgent', agentId: id, createdAt: entry ? activityAt(entry) : 0 })
+    setTabsState(next)
+    // In a split layout the freshly opened tab lands in the active pane.
+    if (layoutRef.current) {
+      const tab = next.tabs.find((c) => c.target === 'agent' && c.state.agentId === id)
+      if (tab) dispatchPane({ type: 'assignTab', tabId: tab.id, paneId: layoutRef.current.activePaneId })
+    }
   }
   /** Opening an agent records the visit and truncates any forward entries. */
   const visit = (id: string) => {
@@ -458,6 +497,10 @@ export function ChatApp() {
   const openWorkspace = (id: string) => {
     setSelectedWorkspaceId(id)
     setCreateError(null)
+    // Restore this host+workspace's persisted pane layout, if any.
+    const persisted = store.get(workspacePanes)[`${daemonHost()}::${id}`] ?? null
+    layoutRef.current = persisted
+    setLayoutState(persisted)
     const descriptor = workspaces.workspaces.find((candidate) => candidate.id === id)
     if (!descriptor) {
       dispatchTabs({ type: 'reset' })
@@ -472,10 +515,117 @@ export function ChatApp() {
     })
   }
 
-  // The composer's stop control: enabled only while the open agent runs. From
-  // click until the cancellation is confirmed — the agent leaving running via
-  // the directory subscription — the control reflects that so double-clicks are
-  // unambiguous.
+  // ---- pane layout operations ----------------------------------------------
+  // These translate user gestures into PaneEvents (and #46 tab events where a
+  // tab's existence is being changed), keeping the pane tree and the #46 tab
+  // strip in one id space. When the layout is null they degrade to the single
+  // tab strip exactly as before.
+
+  /** Split the active pane right or down; materializes a split layout on demand. */
+  const splitActivePane = (direction: 'right' | 'down') => {
+    const layout = layoutRef.current
+    if (layout) {
+      const target = layout.activePaneId
+      if (!target) return
+      dispatchPane(direction === 'right' ? { type: 'splitRight', paneId: target } : { type: 'splitDown', paneId: target })
+      return
+    }
+    // No split yet: materialize the default single pane (which hosts the
+    // workspace's tabs) and split it.
+    const single: PaneLayoutState = { root: leafFor(tabs.map((t) => t.id), tabsState.activeTabId), activePaneId: '' }
+    layoutRef.current = single
+    const target = single.root.id
+    const next = reduceLayout(single, direction === 'right' ? { type: 'splitRight', paneId: target } : { type: 'splitDown', paneId: target })
+    setLayoutState(next)
+    persistLayout(next)
+  }
+
+  /** Select a tab inside a pane; keeps #46's focus in sync for the non-split path. */
+  const selectTabInPane = (paneId: string, tabId: string) => {
+    if (layoutRef.current) dispatchPane({ type: 'focusTab', paneId, tabId })
+    dispatchTabs({ type: 'select', tabId })
+  }
+
+  /** Close a tab: drop it from #46 and remove its pane references (wherever it lives). */
+  const closeTabInPane = (_paneId: string, tabId: string) => {
+    dispatchTabs({ type: 'close', tabId })
+    if (layoutRef.current) dispatchPane({ type: 'removeTab', tabId })
+  }
+
+  /** Close every other tab in a pane, keeping `tabId` focused there. */
+  const closeOthersInPane = (paneId: string, tabId: string) => {
+    const layout = layoutRef.current
+    if (!layout) return
+    const others = paneTabIds(layout.root, paneId).filter((id) => id !== tabId)
+    for (const other of others) {
+      dispatchTabs({ type: 'close', tabId: other })
+      dispatchPane({ type: 'removeTab', tabId: other })
+    }
+    dispatchPane({ type: 'focusTab', paneId, tabId })
+  }
+
+  /** Append a new draft tab into a specific pane (or the single strip). */
+  const openDraftInPane = (paneId: string) => {
+    const dir = activeDraft?.cwd ?? cwd
+    const next = reduceTabs(tabsState, { type: 'openDraft', cwd: dir, now: Date.now() })
+    setTabsState(next)
+    const newTab = next.tabs.at(-1)
+    if (newTab && layoutRef.current) dispatchPane({ type: 'assignTab', tabId: newTab.id, paneId })
+  }
+
+  /** Cycle pane or tab focus via the keyboard (both directions, wrapping). */
+  const cyclePane = (direction: 'next' | 'prev', kind: 'pane' | 'tab') => {
+    if (!layoutRef.current) return
+    const event: PaneEvent =
+      kind === 'pane'
+        ? direction === 'next'
+          ? { type: 'focusNextPane' }
+          : { type: 'focusPrevPane' }
+        : direction === 'next'
+          ? { type: 'focusNextTab' }
+          : { type: 'focusPrevTab' }
+    dispatchPane(event)
+  }
+
+  /** Move the active tab to the first/next pane in the walk (a simple move op). */
+  const moveActiveTabToNextPane = () => {
+    const layout = layoutRef.current
+    if (!layout) return
+    const leaves = paneLeaves(layout.root)
+    if (leaves.length < 2) return
+    const idx = leaves.findIndex((l) => l.id === layout.activePaneId)
+    const next = leaves[(idx + 1) % leaves.length]!
+    const focusedTab = activePaneTabId(layout)
+    if (!focusedTab) return
+    dispatchPane({ type: 'moveTab', tabId: focusedTab, fromPaneId: layout.activePaneId, toPaneId: next.id })
+  }
+
+  // Pane keyboard control: Cmd/Ctrl+Alt+←/→ cycles panes, Cmd/Ctrl+Alt+↑/↓
+  // cycles tabs, Cmd/Ctrl+Shift+←/→ splits the active pane, Cmd/Ctrl+Shift+↑
+  // moves the active tab to the next pane.
+  useWindowEvent((event) => {
+    if (event.eventType !== 'keyDown') return
+    const mod = event.modifiers
+    if (!mod || !(mod.cmd || mod.ctrl)) return
+    if (mod.alt && !mod.shift) {
+      if (event.key === 'ArrowRight') cyclePane('next', 'pane')
+      else if (event.key === 'ArrowLeft') cyclePane('prev', 'pane')
+      else if (event.key === 'ArrowDown') cyclePane('next', 'tab')
+      else if (event.key === 'ArrowUp') cyclePane('prev', 'tab')
+      return
+    }
+    if (mod.shift && !mod.alt) {
+      if (event.key === 'ArrowRight') splitActivePane('right')
+      else if (event.key === 'ArrowDown') splitActivePane('down')
+      else if (event.key === 'ArrowUp') moveActiveTabToNextPane()
+    }
+  })
+
+  // Seed a materialized single-pane leaf for the first split.
+  function leafFor(tabIds: string[], focused: string | null) {
+    return { kind: 'leaf' as const, id: 'root', tabIds, focusedTabId: focused }
+  }
+
   const agentRunning = activeEntry?.status === 'running'
   const [stopping, setStopping] = useState(false)
   useEffect(() => setStopping(false), [activeId])
@@ -843,6 +993,8 @@ export function ChatApp() {
         run: () => {
           dispatchTabs({ type: 'reset' })
           setSelectedWorkspaceId(null)
+          setLayoutState(null)
+          layoutRef.current = null
           // Same rule as the sidebar's New Task: no phantom future survives.
           setVisitHistory(truncateForward)
           setCreateError(null)
@@ -987,6 +1139,70 @@ export function ChatApp() {
         }
       : undefined
 
+  // ---- multi-pane rendering --------------------------------------------------
+  // In a split layout each pane shows its own tab strip (PaneSplit owns it) and
+  // this content area below it: the focused agent panel, a draft center message,
+  // or an empty-pane hint. All of a pane's agent panels stay mounted (streaming
+  // live) with only the focused one visible, matching the single-pane rule.
+  const paneMeta: PaneStripMeta = {
+    labelFor: (tab) => {
+      if (tab.target === 'agent') {
+        const entry = agents.find((candidate) => candidate.id === tab.state.agentId)
+        return entry ? displayName(entry) : 'Agent'
+      }
+      if (tab.target === 'draft') return basename(tab.state.cwd)
+      return 'Workspace setup'
+    },
+    dotColorFor: (tab) => {
+      if (tab.target !== 'agent') return null
+      const entry = agents.find((candidate) => candidate.id === tab.state.agentId)
+      return entry ? agentStatusColor(entry) : null
+    },
+    attentionFor: (tab) => {
+      if (tab.target !== 'agent') return false
+      return Boolean(agents.find((candidate) => candidate.id === tab.state.agentId)?.requiresAttention)
+    },
+  }
+  const renderPaneContent = (paneId: string, tabIds: string[], focusedTabId: string | null): React.ReactNode => {
+    const focusedTab = tabs.find((t) => t.id === focusedTabId) ?? null
+    if (!focusedTabId || tabIds.length === 0 || !focusedTab) {
+      return <CenterMessage title="Empty pane" detail="Open an agent here, or close this pane." />
+    }
+    if (focusedTab.target === 'draft') {
+      return <CenterMessage title="New draft" detail={`Describe what to build in ${basename(focusedTab.state.cwd)}.`} />
+    }
+    if (focusedTab.target !== 'agent') {
+      return <CenterMessage title="No agent here" detail="Pick an agent for this pane." />
+    }
+    const isActivePane = paneId === layoutRef.current?.activePaneId
+    return (
+      <>
+        {tabIds.map((id) => {
+          const tab = tabs.find((t) => t.id === id)
+          return tab && tab.target === 'agent' ? (
+            <AgentTabPanel
+              key={tab.id}
+              client={client}
+              daemon={daemon}
+              agentId={tab.state.agentId}
+              seedText={pendingSeed?.agentId === tab.state.agentId ? pendingSeed.text : null}
+              seedImages={pendingSeed?.agentId === tab.state.agentId ? pendingSeed.images : null}
+              onSeedConsumed={() => {
+                if (pendingSeed?.agentId === tab.state.agentId) setPendingSeed(null)
+              }}
+              hidden={tab.id !== focusedTabId}
+              showTranscript={isActivePane && tab.id === focusedTabId ? !viewingSubagent : false}
+              onConversation={(id, conv) => conversationsRef.current.set(id, conv)}
+              onEditQueued={editQueued}
+              onOpenFile={openFile}
+              workspaceRoot={agents.find((a) => a.id === tab.state.agentId)?.cwd ?? null}
+            />
+          ) : null
+        })}
+      </>
+    )
+  }
+
   return (
     <div
       style={{
@@ -1028,6 +1244,8 @@ export function ChatApp() {
             // phantom future the visited stack was still holding.
             setVisitHistory(truncateForward)
             setSelectedWorkspaceId(null)
+            setLayoutState(null)
+            layoutRef.current = null
             setCreateError(null)
           }}
           onCollapse={() => setCollapsed(true)}
@@ -1100,7 +1318,20 @@ export function ChatApp() {
             onBack={() => setViewing(null)}
           />
         )}
-        {tabs.length > 0 && (
+        {layoutState ? (
+          <PaneSplit
+            layout={layoutState}
+            tabs={tabs}
+            meta={paneMeta}
+            renderPane={renderPaneContent}
+            onSelectTab={selectTabInPane}
+            onCloseTab={closeTabInPane}
+            onCloseOthers={closeOthersInPane}
+            onNewDraft={openDraftInPane}
+          />
+        ) : (
+          <>
+          {tabs.length > 0 && (
           <TabStrip
             tabs={tabs}
             activeTabId={activeTabId}
@@ -1126,64 +1357,66 @@ export function ChatApp() {
             onCloseOthers={(tabId) => dispatchTabs({ type: 'closeOthers', tabId })}
             onNewDraft={() => dispatchTabs({ type: 'openDraft', cwd: activeDraft?.cwd ?? cwd, now: Date.now() })}
           />
-        )}
-        {status === 'error' ? (
-          <CenterMessage
-            title={`Cannot reach ${daemonHost()}`}
-            detail={`${error}\n\nStart a daemon with: npm install -g @getpaseo/cli && paseo`}
-          />
-        ) : status === 'connecting' ? (
-          <CenterMessage title={`Connecting to ${daemonHost()}…`} />
-        ) : viewingSubagent ? (
-          <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minHeight: 0 }}>
-            {subagentHasOlder(subagents.state, viewingSubagent.parentAgentId, viewingSubagent.id) && (
-              <SubagentLoadOlder
-                loading={subagents.loadingOlder}
-                onClick={() =>
-                  subagents.loadOlder(viewingSubagent.parentAgentId, viewingSubagent.id)
-                }
+          )}
+          {status === 'error' ? (
+            <CenterMessage
+              title={`Cannot reach ${daemonHost()}`}
+              detail={`${error}\n\nStart a daemon with: npm install -g @getpaseo/cli && paseo`}
+            />
+          ) : status === 'connecting' ? (
+            <CenterMessage title={`Connecting to ${daemonHost()}…`} />
+          ) : viewingSubagent ? (
+            <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minHeight: 0 }}>
+              {subagentHasOlder(subagents.state, viewingSubagent.parentAgentId, viewingSubagent.id) && (
+                <SubagentLoadOlder
+                  loading={subagents.loadingOlder}
+                  onClick={() =>
+                    subagents.loadOlder(viewingSubagent.parentAgentId, viewingSubagent.id)
+                  }
+                />
+              )}
+              <Transcript
+                turns={providerTurns}
+                permissions={[]}
+                onRespond={undefined}
+                onEditQueued={undefined}
+                listRef={subagentListRef}
+                detached={!subagentFollow.following}
+                onScroll={subagentFollow.onScroll}
+                onJumpToBottom={subagentFollow.requestJump}
+                onJumpToTurn={subagentFollow.jumpToTurn}
               />
-            )}
-            <Transcript
-              turns={providerTurns}
-              permissions={[]}
-              onRespond={undefined}
-              onEditQueued={undefined}
-              listRef={subagentListRef}
-              detached={!subagentFollow.following}
-              onScroll={subagentFollow.onScroll}
-              onJumpToBottom={subagentFollow.requestJump}
-              onJumpToTurn={subagentFollow.jumpToTurn}
+            </div>
+          ) : activeId == null ? (
+            <CenterMessage
+              title={activeDraft ? 'New draft' : 'New task'}
+              detail={`Pick a model, then describe what to build in ${basename(activeDraft?.cwd ?? cwd)}.`}
             />
-          </div>
-        ) : activeId == null ? (
-          <CenterMessage
-            title={activeDraft ? 'New draft' : 'New task'}
-            detail={`Pick a model, then describe what to build in ${basename(activeDraft?.cwd ?? cwd)}.`}
-          />
-        ) : null}
-        {/* Every open agent tab stays mounted so its timeline keeps streaming;
-            only the focused one is visible. */}
-        {tabs.map((tab) =>
-          tab.target === 'agent' ? (
-            <AgentTabPanel
-              key={tab.id}
-              client={client}
-              daemon={daemon}
-              agentId={tab.state.agentId}
-              seedText={pendingSeed?.agentId === tab.state.agentId ? pendingSeed.text : null}
-              seedImages={pendingSeed?.agentId === tab.state.agentId ? pendingSeed.images : null}
-              onSeedConsumed={() => {
-                if (pendingSeed?.agentId === tab.state.agentId) setPendingSeed(null)
-              }}
-              hidden={tab.id !== activeTabId}
-              showTranscript={tab.id === activeTabId ? !viewingSubagent : false}
-              onConversation={(id, conv) => conversationsRef.current.set(id, conv)}
-              onEditQueued={editQueued}
-              onOpenFile={openFile}
-              workspaceRoot={agents.find((a) => a.id === tab.state.agentId)?.cwd ?? null}
-            />
-          ) : null,
+          ) : null}
+          {/* Every open agent tab stays mounted so its timeline keeps streaming;
+              only the focused one is visible. */}
+          {tabs.map((tab) =>
+            tab.target === 'agent' ? (
+              <AgentTabPanel
+                key={tab.id}
+                client={client}
+                daemon={daemon}
+                agentId={tab.state.agentId}
+                seedText={pendingSeed?.agentId === tab.state.agentId ? pendingSeed.text : null}
+                seedImages={pendingSeed?.agentId === tab.state.agentId ? pendingSeed.images : null}
+                onSeedConsumed={() => {
+                  if (pendingSeed?.agentId === tab.state.agentId) setPendingSeed(null)
+                }}
+                hidden={tab.id !== activeTabId}
+                showTranscript={tab.id === activeTabId ? !viewingSubagent : false}
+                onConversation={(id, conv) => conversationsRef.current.set(id, conv)}
+                onEditQueued={editQueued}
+                onOpenFile={openFile}
+                workspaceRoot={agents.find((a) => a.id === tab.state.agentId)?.cwd ?? null}
+              />
+            ) : null,
+          )}
+          </>
         )}
         {createError && (
           <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center', paddingBottom: 4 }}>

--- a/chat.tsx
+++ b/chat.tsx
@@ -18,6 +18,7 @@ import type { DaemonClient } from '@getpaseo/client/internal/daemon-client'
 import {
   DAEMON_URL,
   activeAgentGone,
+  activityAt,
   applyAgentPage,
   applyAgentUpdate,
   basename,
@@ -72,10 +73,8 @@ import { Sidebar, Header, CenterMessage, agentStatusColor, daemonHost, type RowA
 import { Transcript } from './conversation/transcript'
 import { FeatureToggles, ModelPicker, OptionPicker, modeOptions, thinkingOptions } from './composer/pickers'
 import { Composer, ConfigNotice, FooterBar, TracksRow } from './composer/composer'
-import { useAgentConversation } from './conversation/conversation'
 import { toMentionEntries, type MentionSource } from './composer/mentions'
 import { useTranscriptFollow } from './conversation/follow'
-import { useAgentPermissions } from './conversation/permissions'
 import { nativeOpenFileBridge, requestOpenFile } from './chrome/open-file'
 import { useAttention, type NotificationBridge } from './conversation/attention'
 import { useDraftConfig } from './composer/draft-config'
@@ -112,6 +111,17 @@ import {
   type OpenSubagent,
 } from './tracks/tracks-panel'
 import { createAppStore, defaultStatePath, fileStateStorage, showArchivedAgents, useAppState } from './app-state'
+import {
+  initialTabs,
+  reduceTabs,
+  selectActiveAgentId,
+  selectActiveDraft,
+  selectActiveTab,
+  selectTabs,
+  type TabsEvent,
+} from './tabs/tabs'
+import { TabStrip } from './tabs/tab-strip'
+import { AgentTabPanel, type TabConversation } from './tabs/agent-tab-panel'
 
 // ---- daemon hooks ----------------------------------------------------------
 
@@ -249,26 +259,58 @@ async function openImagePicker(): Promise<IncomingImage[] | null> {
 /** One store per app run: read the state file once, persist every write. */
 const createStateStore = () => createAppStore(fileStateStorage(defaultStatePath()))
 
+/**
+ * The slice of an agent conversation the app-level chrome consumes (composer,
+ * tracks row, context meter). Panels own the full conversation and register it
+ * in the ref map; this keeps the app decoupled from the per-tab lifecycle.
+ */
+type ComposerConversation = Pick<
+  TabConversation,
+  'turns' | 'parked' | 'pending' | 'status' | 'usage' | 'send' | 'park' | 'release' | 'unqueue'
+>
+
 export function ChatApp() {
   const { client, daemon, status, error, agents, providers, workspaces } = useDaemon()
   const [store] = useState(createStateStore)
 
-  const [activeId, setActiveId] = useState<string | null>(null)
+  const everShownAgentIds = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    for (const entry of agents) everShownAgentIds.current.add(entry.id)
+  }, [agents])
+
+  // Workspace tabs: the strip of open agent + draft tabs with a focused one.
+  // The reducer owns every add/close/select decision; this component only
+  // translates gestures and daemon results into TabsEvents. `activeId` stays
+  // the single "selected agent" the rest of the app reasons about — whichever
+  // agent tab is focused, or null for a draft/no-tab state.
+  const [tabsState, setTabsState] = useState(initialTabs)
+  const dispatchTabs = (event: TabsEvent) => setTabsState((prev) => reduceTabs(prev, event))
+  const tabs = selectTabs(tabsState)
+  const activeTab = selectActiveTab(tabsState)
+  const activeTabId = tabsState.activeTabId
+  const activeAgentId = selectActiveAgentId(tabsState)
+  const activeDraft = selectActiveDraft(tabsState)
+  const activeId = activeAgentId
   // Visited-agent history behind the chrome's back/forward arrows: opening an
   // agent records the visit, back/forward only move the cursor. An explicit
   // extension of Paseo's own navigation model (no upstream visited-history
   // stack exists); see ticket #21's parity note.
   const [visitHistory, setVisitHistory] = useState<VisitHistory>(emptyVisitHistory)
+  /** Opens (or focuses) an agent's tab; recency seeds its strip position. */
+  const openAgentTab = (id: string) => {
+    const entry = agents.find((candidate) => candidate.id === id) ?? null
+    dispatchTabs({ type: 'openAgent', agentId: id, createdAt: entry ? activityAt(entry) : 0 })
+  }
   /** Opening an agent records the visit and truncates any forward entries. */
   const visit = (id: string) => {
-    setActiveId(id)
+    openAgentTab(id)
     setVisitHistory((prev) => visitAgent(prev, id))
   }
   const nav = (delta: 1 | -1) => {
     const next = delta < 0 ? goBack(visitHistory) : goForward(visitHistory)
     if (next === visitHistory) return
     setVisitHistory(next)
-    setActiveId(next.stack[next.index])
+    openAgentTab(next.stack[next.index]!)
   }
   const navState = { canBack: canGoBack(visitHistory), canForward: canGoForward(visitHistory) }
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null)
@@ -302,13 +344,26 @@ export function ChatApp() {
   const [cwd, setCwd] = useState(process.cwd())
   const [worktree, setWorktree] = useState('local')
 
-  const conversation = useAgentConversation(client, activeId, {
-    seedText: seed?.text ?? null,
-    seedImages: seed?.images ?? null,
-    onSeedConsumed: () => setPendingSeed(null),
+  // Each open agent tab owns its timeline subscription inside its own panel —
+  // kept mounted (hide-not-unmount) so background tabs keep merging. The
+  // active tab's conversation powers the composer, tracks row, and meter below;
+  // a stable no-op stands in for draft/no-agent states (send/park are inert).
+  const conversationsRef = useRef<Map<string, ComposerConversation>>(new Map())
+  const emptyConversation = useRef<ComposerConversation>({
+    turns: [],
+    parked: [],
+    pending: [],
+    status: 'loading',
+    usage: null,
+    send: async () => false,
+    park: () => {},
+    release: async () => false,
+    unqueue: () => {},
   })
+  const conversation: ComposerConversation = activeId
+    ? conversationsRef.current.get(activeId) ?? emptyConversation.current
+    : emptyConversation.current
   const turns = conversation.turns
-  const permissions = useAgentPermissions(client, daemon, activeId)
   // No OS notifier exists in @gpuix yet, so delivery silently no-ops; the
   // payloads are ready for a runtime bridge — clicking one deep-links by
   // re-selecting notice.payload.agentId.
@@ -326,22 +381,16 @@ export function ChatApp() {
   const activeRepoKey = activeStatus ? repoKeyOf(activeStatus) : (activeEntry?.cwd ?? null)
   const activeQueue = activeRepoKey ? repoActions.state.repos[activeRepoKey] : undefined
 
-  // Ids the directory has shown, so a just-created agent isn't judged gone
-  // while its upsert is still in flight.
-  const everShownAgentIds = useRef<Set<string>>(new Set())
-  useEffect(() => {
-    for (const entry of agents) everShownAgentIds.current.add(entry.id)
-  }, [agents])
-
-  // An agent that vanished from the directory (deleted) or was archived can no
-  // longer host a conversation — Paseo's own client redirects away in both cases.
+  // An agent that vanished from the directory (deleted) can no longer host a
+  // conversation — Paseo's own client redirects away in both cases. Its tab is
+  // closed, which lands on the neighbor (or the empty new-task state).
   const activeEntryGone = activeAgentGone(activeId, agents, {
     connected: status === 'connected',
     wasSeen: activeId != null && everShownAgentIds.current.has(activeId),
   })
   useEffect(() => {
-    if (activeEntryGone) setActiveId(null)
-  }, [activeEntryGone])
+    if (activeEntryGone && activeTab) dispatchTabs({ type: 'close', tabId: activeTab.id })
+  }, [activeEntryGone, activeTab])
 
   // Row lifecycle actions disable per row while their daemon call is in flight;
   // directory truth arrives through the subscription, never from these results.
@@ -369,28 +418,26 @@ export function ChatApp() {
     runRowAction('rename', id, () => daemon.updateAgent(id, { name: name.trim() }))
 
   /**
-   * Opening a workspace opens its conversation: its most recently active agent
-   * becomes the shown timeline; a workspace with no agents falls back to the
-   * composer's new-task state seeded to that workspace's directory.
+   * Opening a workspace replaces the strip with that workspace's tabs: an
+   * agent tab per non-archived agent (most recent first), plus a trailing draft
+   * tab seeded to the workspace directory for starting something new. A
+   * workspace with no agents yields just that draft tab.
    */
   const openWorkspace = (id: string) => {
     setSelectedWorkspaceId(id)
     setCreateError(null)
     const descriptor = workspaces.workspaces.find((candidate) => candidate.id === id)
     if (!descriptor) {
-      setActiveId(null)
+      dispatchTabs({ type: 'reset' })
       return
     }
-    const agent = mostRecentAgent(agentsOfWorkspace(agents, descriptor).filter((a) => !isArchived(a)))
-    if (agent) {
-      visit(agent.id)
-    } else {
-      // Seeding means the send lands in the workspace as it is — never a new
-      // worktree on top of it.
-      setActiveId(null)
-      setCwd(workspaceDirectory(descriptor))
-      setWorktree('local')
-    }
+    const workspaceAgents = agentsOfWorkspace(agents, descriptor).filter((a) => !isArchived(a))
+    dispatchTabs({
+      type: 'openWorkspace',
+      agents: workspaceAgents.map((a) => ({ id: a.id, createdAt: activityAt(a) })),
+      cwd: workspaceDirectory(descriptor),
+      now: Date.now(),
+    })
   }
 
   // The composer's stop control: enabled only while the open agent runs. From
@@ -442,6 +489,19 @@ export function ChatApp() {
     viewingSubagent
       ? subagentTurns(subagents.state, viewingSubagent.parentAgentId, viewingSubagent.id)
       : []
+
+  // The provider-subagent viewer sits on top of the tabs and carries its own
+  // list and follow; agent tabs manage theirs inside their panels.
+  const subagentListRef = useRef<{ id: number } | null>(null)
+  const { renderer } = useGpuix()
+  const subagentFollow = useTranscriptFollow({
+    listRef: subagentListRef,
+    turnCount: providerTurns.length,
+    tailSignature: providerTurns.length > 0 ? JSON.stringify(providerTurns.at(-1)) : undefined,
+    agentId: viewingSubagent?.parentAgentId ?? activeId,
+    renderer,
+    slotOffset: 0,
+  })
 
   const viewSubagent = (target: OpenSubagent) => {
     if (target.kind === 'managed') {
@@ -511,39 +571,9 @@ export function ChatApp() {
     [sessionUsage, modelDef],
   )
 
-  // The transcript area shows the parent conversation, or a provider
-  // subagent's read-only timeline while it is open.
-  const visibleTurns = turns
-  const shownTurns = viewingSubagent ? providerTurns : visibleTurns
-
-  // Older-history availability for the transcript's top edge: quiet while more
-  // pages exist unrequested, a spinner while fetching, a marker once exhausted.
-  const olderPages =
-    conversation.status === 'ready' && visibleTurns.length > 0
-      ? conversation.loadingHistory
-        ? ('loading' as const)
-        : conversation.hasOlder
-          ? ('more' as const)
-          : ('end' as const)
-      : undefined
-
-const listRef = useRef<{ id: number } | null>(null)
-  const { renderer } = useGpuix()
-  // Follow tracks the list actually rendered: the parent transcript normally,
-  // the open provider subagent's timeline while the viewer is up.
-  const { following, onScroll, requestJump, jumpToTurn } = useTranscriptFollow({
-    listRef,
-    turnCount: shownTurns.length,
-    // The final turn's identity, so a history page prepended above the viewport
-    // (count grew, tail sat still) doesn't drag a following view back down.
-    tailSignature: shownTurns.length > 0 ? JSON.stringify(shownTurns.at(-1)) : undefined,
-    agentId: viewingSubagent ? viewingSubagent.parentAgentId : activeId,
-    renderer,
-    // HistoryHead occupies virtual-list slot 0 whenever older history does (or
-    // may) exist upstream, so every turn row is shifted down by one. The
-    // subagent viewer pages history with its own head-free list.
-    slotOffset: viewingSubagent ? 0 : olderPages ? 1 : 0,
-  })
+  // The transcript area (parent conversation, provider-subagent viewer, and
+  // its scroll state) lives inside per-tab conversation panels so background
+  // tabs keep streaming; nothing scroll- or history-related lives here any more.
 
   /** Clears the composer after the text (and chips) have found a home. */
   const clearDraft = () => {
@@ -608,6 +638,10 @@ const listRef = useRef<{ id: number } | null>(null)
       restoreDraft(text, stagedImages)
       return
     }
+    // A draft tab creates the agent in its own directory; the directory
+    // new-task state uses the composer's cwd/worktree choices.
+    const createDir = activeDraft?.cwd ?? cwd
+    const createWorktree = activeDraft?.worktree ?? worktree
     try {
       const config: PaseoAgentConfig = { provider: modelValue }
       if (modeId) config.modeId = modeId
@@ -615,13 +649,25 @@ const listRef = useRef<{ id: number } | null>(null)
       if (Object.keys(featureValues).length > 0) config.featureValues = { ...featureValues }
       const handle = await client.agents.create({
         config,
-        cwd,
+        cwd: createDir,
         prompt: text,
         ...(outgoing.length > 0 ? { images: outgoing } : {}),
-        ...(worktree === 'worktree' ? { git: { createWorktree: true } } : {}),
+        ...(createWorktree === 'worktree' ? { git: { createWorktree: true } } : {}),
       })
       setPendingSeed({ agentId: handle.id, text, images: stagedImages })
-      visit(handle.id)
+      setVisitHistory((prev) => visitAgent(prev, handle.id))
+      if (activeTab && activeDraft) {
+        // The draft tab flips into the new agent's tab and stays focused.
+        dispatchTabs({
+          type: 'draftSent',
+          tabId: activeTab.id,
+          agentId: handle.id,
+          createdAt: Date.now(),
+        })
+      } else {
+        // Directory new-task: open the new agent as its own tab.
+        openAgentTab(handle.id)
+      }
     } catch (err) {
       setCreateError(errorMessage(err))
       restoreDraft(text, stagedImages)
@@ -732,7 +778,7 @@ const listRef = useRef<{ id: number } | null>(null)
 
   // `@` completion lists the selected agent's workspace, or the chosen one for
   // a new task. Daemon errors degrade to no suggestions inside the hook.
-  const mentionCwd = activeEntry?.cwd ?? cwd
+  const mentionCwd = activeEntry?.cwd ?? activeDraft?.cwd ?? cwd
   const mentionSource = useMemo<MentionSource>(
     () => ({
       cwd: mentionCwd,
@@ -763,7 +809,8 @@ const listRef = useRef<{ id: number } | null>(null)
         section: 'actions',
         keywords: 'compose new agent',
         run: () => {
-          setActiveId(null)
+          dispatchTabs({ type: 'reset' })
+          setSelectedWorkspaceId(null)
           // Same rule as the sidebar's New Task: no phantom future survives.
           setVisitHistory(truncateForward)
           setCreateError(null)
@@ -803,8 +850,9 @@ const listRef = useRef<{ id: number } | null>(null)
   useContributeActions(
     registry,
     () => {
-      // The workspace footer locks while an agent owns the conversation.
-      if (activeEntry) return []
+      // The workspace footer locks while a tab owns the conversation (an agent
+      // or a draft tab carries its own directory).
+      if (activeEntry || activeDraft) return []
       return [...new Set([process.cwd(), ...cwdOptions])].map((dir) => ({
         id: `workspace.${dir}`,
         title: basename(dir),
@@ -903,7 +951,7 @@ const listRef = useRef<{ id: number } | null>(null)
       ? {
           seam: daemon,
           agentId: activeId,
-          draft: activeId ? null : { modelValue, thinkingId, modeId, cwd },
+          draft: activeId ? null : { modelValue, thinkingId, modeId, cwd: activeDraft?.cwd ?? cwd },
         }
       : undefined
 
@@ -943,7 +991,7 @@ const listRef = useRef<{ id: number } | null>(null)
           }}
           onDeleteAgent={deleteAgentRow}
           onNewTask={() => {
-            setActiveId(null)
+            dispatchTabs({ type: 'reset' })
             // Starting a new task is a fresh edge, not a forward jump: drop any
             // phantom future the visited stack was still holding.
             setVisitHistory(truncateForward)
@@ -1015,6 +1063,33 @@ const listRef = useRef<{ id: number } | null>(null)
             onBack={() => setViewing(null)}
           />
         )}
+        {tabs.length > 0 && (
+          <TabStrip
+            tabs={tabs}
+            activeTabId={activeTabId}
+            labelFor={(tab) => {
+              if (tab.target === 'agent') {
+                const entry = agents.find((candidate) => candidate.id === tab.state.agentId)
+                return entry ? displayName(entry) : 'Agent'
+              }
+              if (tab.target === 'draft') return basename(tab.state.cwd)
+              return 'Workspace setup'
+            }}
+            dotColorFor={(tab) => {
+              if (tab.target !== 'agent') return null
+              const entry = agents.find((candidate) => candidate.id === tab.state.agentId)
+              return entry ? agentStatusColor(entry) : null
+            }}
+            attentionFor={(tab) => {
+              if (tab.target !== 'agent') return false
+              return Boolean(agents.find((candidate) => candidate.id === tab.state.agentId)?.requiresAttention)
+            }}
+            onSelect={(tabId) => dispatchTabs({ type: 'select', tabId })}
+            onClose={(tabId) => dispatchTabs({ type: 'close', tabId })}
+            onCloseOthers={(tabId) => dispatchTabs({ type: 'closeOthers', tabId })}
+            onNewDraft={() => dispatchTabs({ type: 'openDraft', cwd: activeDraft?.cwd ?? cwd, now: Date.now() })}
+          />
+        )}
         {status === 'error' ? (
           <CenterMessage
             title={`Cannot reach ${daemonHost()}`}
@@ -1022,17 +1097,8 @@ const listRef = useRef<{ id: number } | null>(null)
           />
         ) : status === 'connecting' ? (
           <CenterMessage title={`Connecting to ${daemonHost()}…`} />
-        ) : shownTurns.length === 0 && (viewingSubagent || permissions.cards.length === 0) ? (
-          <CenterMessage
-            title={viewingSubagent ? 'Loading subagent…' : activeId ? 'Starting agent…' : 'New task'}
-            detail={
-              viewingSubagent || activeId
-                ? undefined
-                : `Pick a model, then describe what to build in ${basename(cwd)}.`
-            }
-          />
         ) : viewingSubagent ? (
-          <>
+          <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minHeight: 0 }}>
             {subagentHasOlder(subagents.state, viewingSubagent.parentAgentId, viewingSubagent.id) && (
               <SubagentLoadOlder
                 loading={subagents.loadingOlder}
@@ -1042,33 +1108,45 @@ const listRef = useRef<{ id: number } | null>(null)
               />
             )}
             <Transcript
-              turns={shownTurns}
+              turns={providerTurns}
               permissions={[]}
               onRespond={undefined}
               onEditQueued={undefined}
-              listRef={listRef}
-              detached={!following}
-              onScroll={onScroll}
-              onJumpToBottom={requestJump}
-              onJumpToTurn={jumpToTurn}
+              listRef={subagentListRef}
+              detached={!subagentFollow.following}
+              onScroll={subagentFollow.onScroll}
+              onJumpToBottom={subagentFollow.requestJump}
+              onJumpToTurn={subagentFollow.jumpToTurn}
             />
-          </>
-        ) : (
-          <Transcript
-            turns={visibleTurns}
-            permissions={permissions.cards}
-            onRespond={permissions.respond}
-            onEditQueued={editQueued}
-            workspaceRoot={activeEntry?.cwd}
-            onOpenFile={openFile}
-            listRef={listRef}
-            olderPages={olderPages}
-            onLoadOlder={conversation.loadHistory}
-            detached={!following}
-            onScroll={onScroll}
-            onJumpToBottom={requestJump}
-            onJumpToTurn={jumpToTurn}
+          </div>
+        ) : activeId == null ? (
+          <CenterMessage
+            title={activeDraft ? 'New draft' : 'New task'}
+            detail={`Pick a model, then describe what to build in ${basename(activeDraft?.cwd ?? cwd)}.`}
           />
+        ) : null}
+        {/* Every open agent tab stays mounted so its timeline keeps streaming;
+            only the focused one is visible. */}
+        {tabs.map((tab) =>
+          tab.target === 'agent' ? (
+            <AgentTabPanel
+              key={tab.id}
+              client={client}
+              daemon={daemon}
+              agentId={tab.state.agentId}
+              seedText={pendingSeed?.agentId === tab.state.agentId ? pendingSeed.text : null}
+              seedImages={pendingSeed?.agentId === tab.state.agentId ? pendingSeed.images : null}
+              onSeedConsumed={() => {
+                if (pendingSeed?.agentId === tab.state.agentId) setPendingSeed(null)
+              }}
+              hidden={tab.id !== activeTabId}
+              showTranscript={tab.id === activeTabId ? !viewingSubagent : false}
+              onConversation={(id, conv) => conversationsRef.current.set(id, conv)}
+              onEditQueued={editQueued}
+              onOpenFile={openFile}
+              workspaceRoot={agents.find((a) => a.id === tab.state.agentId)?.cwd ?? null}
+            />
+          ) : null,
         )}
         {createError && (
           <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center', paddingBottom: 4 }}>
@@ -1120,16 +1198,22 @@ const listRef = useRef<{ id: number } | null>(null)
           mentionSource={mentionSource}
         />
         <FooterBar
-          cwd={activeEntry?.cwd ?? cwd}
-          cwdLocked={Boolean(activeEntry)}
+          cwd={activeEntry?.cwd ?? activeDraft?.cwd ?? cwd}
+          cwdLocked={Boolean(activeEntry) || Boolean(activeDraft)}
           cwdOptions={[process.cwd(), ...cwdOptions]}
           onCwdChange={(dir) => {
             setCwd(dir)
             // A fresh directory selection mid-stack leaves no phantom future.
             setVisitHistory(truncateForward)
           }}
-          worktree={worktree}
-          onWorktreeChange={setWorktree}
+          worktree={activeDraft?.worktree ?? worktree}
+          onWorktreeChange={(next) => {
+            if (activeTab && activeDraft) {
+              dispatchTabs({ type: 'setDraftWorktree', tabId: activeTab.id, worktree: next as 'local' | 'worktree' })
+            } else {
+              setWorktree(next)
+            }
+          }}
           statusColor={
             activeEntry
               ? agentStatusColor(activeEntry)

--- a/chrome/chrome.tsx
+++ b/chrome/chrome.tsx
@@ -7,7 +7,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import React, { useMemo, useState } from 'react'
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@gpuix/react'
+import { Select, SelectContent, SelectItem, SelectLabel, SelectSeparator, SelectTrigger } from '@gpuix/react'
 import {
   DAEMON_URL,
   displayName,
@@ -22,8 +22,12 @@ import {
 import {
   aggregateWorkspaceStatus,
   isArchivedWorkspace,
+  visibleWorkspaces,
   workspaceActivityAt,
+  workspaceBranchName,
+  workspaceDirectory,
   workspaceDisplayName,
+  workspaceLabels,
   workspaceProjectGroups,
   type WorkspaceAggregateStatus,
   type WorkspaceStore,
@@ -231,7 +235,14 @@ function SidebarAction({
   )
 }
 
-export type RowActionVerb = 'rename' | 'archive' | 'delete' | 'detach'
+export type RowActionVerb =
+  | 'rename'
+  | 'archive'
+  | 'delete'
+  | 'detach'
+  | 'pin'
+  | 'labels'
+  | 'mark-read'
 
 /** One row lifecycle call in flight; every action on that row stays disabled until it settles. */
 export interface RowActionRef {
@@ -398,22 +409,42 @@ function WorkspaceRow({
   descriptor,
   active,
   busy,
+  busyVerb,
+  availableLabels,
   onSelect,
   onRename,
   onArchive,
+  onCopy,
+  onMarkRead,
+  onPin,
+  onToggleLabel,
+  onClearLabels,
 }: {
   descriptor: WorkspaceDescriptor
   active: boolean
-  /** True while any lifecycle action on this row is in flight. */
+  /** True while any lifecycle action on this row is in flight; disables every action. */
   busy: boolean
+  /** The verb of the in-flight action, to drive per-action pending copy. */
+  busyVerb: RowActionVerb | null
+  /** The union of label names the submenu can toggle, drawn from the visible directory. */
+  availableLabels: string[]
   onSelect: (id: string) => void
   onRename: (id: string, name: string) => void
   onArchive: (id: string) => void
+  onCopy: (value: string) => void
+  onMarkRead: (id: string) => void
+  onPin: (id: string, pinned: boolean) => void
+  onToggleLabel: (id: string, name: string, applied: boolean) => void
+  onClearLabels: (id: string) => void
 }) {
   const [hover, setHover] = useState(false)
   const [renaming, setRenaming] = useState(false)
   const [nameDraft, setNameDraft] = useState('')
   const archived = isArchivedWorkspace(descriptor)
+  const pinned = descriptor.pinnedAt != null
+  const branch = workspaceBranchName(descriptor)
+  const appliedLabels = descriptor.labels ?? []
+  const archiving = busyVerb === 'archive'
   // The meta line resolves the row's whole second line from the descriptor's
   // runtime fields; slots without backing data are absent, and a line with
   // nothing at all renders nothing rather than dead space.
@@ -436,10 +467,34 @@ function WorkspaceRow({
     onRename(descriptor.id, next)
   }
 
-  const runAction = (action: RowActionVerb) => {
+  /**
+   * Dispatches a menu value. Copy/pin/labels/mark-read are the ticket's new
+   * row actions; labels arrive as `label:<name>`. Busy disables everything
+   * until the in-flight call settles, so a guard up front is all we need.
+   */
+  const runAction = (value: string) => {
     if (busy) return
-    if (action === 'rename') startRename()
-    else onArchive(descriptor.id)
+    if (value === 'rename') {
+      startRename()
+    } else if (value === 'copy-path') {
+      const directory = workspaceDirectory(descriptor)
+      if (directory) onCopy(directory)
+    } else if (value === 'copy-branch') {
+      if (branch) onCopy(branch)
+    } else if (value === 'mark-read') {
+      onMarkRead(descriptor.id)
+    } else if (value === 'pin') {
+      onPin(descriptor.id, true)
+    } else if (value === 'unpin') {
+      onPin(descriptor.id, false)
+    } else if (value === 'labels-clear') {
+      onClearLabels(descriptor.id)
+    } else if (value.startsWith('label:')) {
+      const name = value.slice('label:'.length)
+      onToggleLabel(descriptor.id, name, !appliedLabels.includes(name))
+    } else if (value === 'archive') {
+      onArchive(descriptor.id)
+    }
   }
 
   return (
@@ -505,17 +560,49 @@ function WorkspaceRow({
             {workspaceRowTitle(descriptor)}
           </text>
           {hover ? (
-            <OverflowMenu
-              testId="workspace-row-menu"
-              side="right"
-              onAction={(action) => runAction(action as RowActionVerb)}
-            >
+            <OverflowMenu testId="workspace-row-menu" side="right" onAction={runAction}>
+              <SelectItem value="copy-path" textValue="Copy path">
+                <MenuAction label="Copy path" disabled={busy || !workspaceDirectory(descriptor)} />
+              </SelectItem>
+              <SelectItem value="copy-branch" textValue="Copy branch name">
+                <MenuAction label="Copy branch name" disabled={busy || !branch} />
+              </SelectItem>
               <SelectItem value="rename" textValue="Rename">
                 <MenuAction label="Rename" disabled={busy} />
               </SelectItem>
+              <SelectItem value="mark-read" textValue="Mark as read">
+                <MenuAction label="Mark as read" disabled={busy} />
+              </SelectItem>
+              <SelectItem value={pinned ? 'unpin' : 'pin'} textValue={pinned ? 'Unpin' : 'Pin to top'}>
+                <MenuAction label={pinned ? 'Unpin' : 'Pin to top'} disabled={busy} />
+              </SelectItem>
+              {availableLabels.length > 0 && (
+                <>
+                  <SelectSeparator />
+                  <SelectLabel
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      height: 22,
+                      paddingLeft: 8,
+                    }}
+                  >
+                    <text style={{ fontSize: 11.5, fontWeight: 500, color: C.ghost }}>Labels</text>
+                  </SelectLabel>
+                  {availableLabels.map((name) => (
+                    <SelectItem key={name} value={`label:${name}`} textValue={name}>
+                      <MenuAction label={name} checked={appliedLabels.includes(name)} disabled={busy} />
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="labels-clear" textValue="Clear all labels">
+                    <MenuAction label="Clear all labels" disabled={busy || appliedLabels.length === 0} />
+                  </SelectItem>
+                </>
+              )}
               {!archived && (
-                <SelectItem value="archive" textValue="Archive">
-                  <MenuAction label="Archive" disabled={busy} />
+                <SelectItem value="archive" textValue={archiving ? 'Archiving…' : 'Archive'}>
+                  <MenuAction label={archiving ? 'Archiving…' : 'Archive'} tone="danger" disabled={busy} />
                 </SelectItem>
               )}
             </OverflowMenu>
@@ -692,8 +779,18 @@ function MetaTrailingView({ trailing }: { trailing: WorkspaceMetaTrailing }) {
   )
 }
 
-/** One row-action menu entry; danger rows carry their own tone. */
-function MenuAction({ label, tone, disabled }: { label: string; tone?: 'danger'; disabled?: boolean }) {
+/** One row-action menu entry; danger rows carry their own tone, checked rows show a check. */
+function MenuAction({
+  label,
+  tone,
+  disabled,
+  checked,
+}: {
+  label: string
+  tone?: 'danger'
+  disabled?: boolean
+  checked?: boolean
+}) {
   return (
     <div
       style={{
@@ -710,9 +807,10 @@ function MenuAction({ label, tone, disabled }: { label: string; tone?: 'danger';
         hover: disabled ? undefined : { backgroundColor: '#404040' },
       }}
     >
-      <text style={{ fontSize: 12.5, fontWeight: 500, color: tone === 'danger' ? C.danger : C.text }}>
+      <text style={{ fontSize: 12.5, fontWeight: 500, color: tone === 'danger' ? C.danger : C.text, flexGrow: 1 }}>
         {label}
       </text>
+      {checked && <Icon name="check" size={11} color={C.secondary} />}
     </div>
   )
 }
@@ -898,6 +996,11 @@ export function Sidebar({
   busyRows,
   onArchive,
   onRename,
+  onCopy,
+  onMarkRead,
+  onPin,
+  onToggleLabel,
+  onClearLabels,
   appStore,
   navState,
   onNavBack,
@@ -920,6 +1023,11 @@ export function Sidebar({
   busyRows: RowActionRef[]
   onArchive: (id: string) => void
   onRename: (id: string, name: string) => void
+  onCopy: (value: string) => void
+  onMarkRead: (id: string) => void
+  onPin: (id: string, pinned: boolean) => void
+  onToggleLabel: (id: string, name: string, applied: boolean) => void
+  onClearLabels: (id: string) => void
   /** Persisted app state; the sidebar's view choices survive a restart. */
   appStore: AppStore
   /** The visited-agent history's edges, driving the nav arrows' enablement. */
@@ -939,6 +1047,12 @@ export function Sidebar({
   const [collapsedProjects, setCollapsedProjects] = useState<ReadonlySet<string>>(new Set())
   const ARCHIVED_GROUP_ID = '__archived__'
   const groups = useMemo(() => workspaceProjectGroups(workspaces, showArchived), [workspaces, showArchived])
+  // The labels submenu lists the union of labels on every visible workspace;
+  // the checked states are the selected descriptor's own labels.
+  const availableLabels = useMemo(
+    () => workspaceLabels(visibleWorkspaces(workspaces.workspaces, showArchived)),
+    [workspaces, showArchived],
+  )
   const archived = useMemo(
     () => (revealArchivedAgents ? sortAgents(agents.filter(isArchived)) : []),
     [agents, revealArchivedAgents],
@@ -1035,17 +1149,27 @@ export function Sidebar({
                 pill={aggregate && <AggregateStatusPill aggregate={aggregate} />}
               />
               {!collapsed &&
-                group.workspaces.map((descriptor) => (
-                  <WorkspaceRow
-                    key={descriptor.id}
-                    descriptor={descriptor}
-                    active={descriptor.id === activeWorkspaceId}
-                    busy={busyRows.some((row) => row.id === descriptor.id)}
-                    onSelect={onSelect}
-                    onRename={onRename}
-                    onArchive={onArchive}
-                  />
-                ))}
+                group.workspaces.map((descriptor) => {
+                  const rowBusy = busyRows.find((row) => row.id === descriptor.id) ?? null
+                  return (
+                    <WorkspaceRow
+                      key={descriptor.id}
+                      descriptor={descriptor}
+                      active={descriptor.id === activeWorkspaceId}
+                      busy={rowBusy != null}
+                      busyVerb={rowBusy?.verb ?? null}
+                      availableLabels={availableLabels}
+                      onSelect={onSelect}
+                      onRename={onRename}
+                      onArchive={onArchive}
+                      onCopy={onCopy}
+                      onMarkRead={onMarkRead}
+                      onPin={onPin}
+                      onToggleLabel={onToggleLabel}
+                      onClearLabels={onClearLabels}
+                    />
+                  )
+                })}
             </div>
           )
         })}

--- a/chrome/chrome.tsx
+++ b/chrome/chrome.tsx
@@ -25,6 +25,7 @@ import {
   visibleWorkspaces,
   workspaceActivityAt,
   workspaceBranchName,
+  workspaceCatalog,
   workspaceDirectory,
   workspaceDisplayName,
   workspaceLabels,
@@ -48,7 +49,6 @@ import {
   hasActiveFilters,
   labelColor,
   UNLABELLED_LABEL,
-  workspaceHost,
   workspaceMatchesFilters,
   type WorkspaceFilters,
 } from '../agent-directory/display-preferences'
@@ -256,6 +256,7 @@ export type RowActionVerb =
   | 'delete'
   | 'detach'
   | 'pin'
+  | 'unpin'
   | 'labels'
   | 'mark-read'
 
@@ -263,6 +264,20 @@ export type RowActionVerb =
 export interface RowActionRef {
   verb: RowActionVerb
   id: string
+}
+
+/**
+ * The momentary pending copy each in-flight verb shows at the row's tail, so a
+ * busy row says what it is doing rather than going quiet while it disables.
+ * Verbs with no visible progress (rename editing inline, copy, delete/detach on
+ * other surfaces) read nothing here.
+ */
+const ROW_PENDING: Partial<Record<RowActionVerb, string>> = {
+  archive: 'Archiving…',
+  pin: 'Pinning…',
+  unpin: 'Unpinning…',
+  labels: 'Updating labels…',
+  'mark-read': 'Marking read…',
 }
 
 const VIEW_MENU_WIDTH = 232
@@ -665,6 +680,9 @@ function WorkspaceRow({
   const branch = workspaceBranchName(descriptor)
   const appliedLabels = descriptor.labels ?? []
   const archiving = busyVerb === 'archive'
+  // The in-flight verb, if any, reads out at the row's tail so a busy row says
+  // what it is doing while every action stays disabled.
+  const pending = busy && busyVerb ? ROW_PENDING[busyVerb] ?? null : null
   // The meta line resolves the row's whole second line from the descriptor's
   // runtime fields; slots without backing data are absent, and a line with
   // nothing at all renders nothing rather than dead space.
@@ -779,6 +797,11 @@ function WorkspaceRow({
           >
             {workspaceRowTitle(descriptor, config)}
           </text>
+          {pending && (
+            <text style={{ fontSize: 12, color: C.ghost, flexShrink: 0 }} testId="workspace-pending">
+              {pending}
+            </text>
+          )}
           {hover ? (
             <OverflowMenu testId="workspace-row-menu" side="right" onAction={runAction}>
               <SelectItem value="copy-path" textValue="Copy path">
@@ -1281,26 +1304,10 @@ export function Sidebar({
   // project groups under a key no workspace can own.
   const [collapsedProjects, setCollapsedProjects] = useState<ReadonlySet<string>>(new Set())
   const ARCHIVED_GROUP_ID = '__archived__'
-  // The filterable catalog derives from the live store: hosts only when more
-  // than one exists, every project, and every label found across workspaces.
-  const catalog = useMemo(() => {
-    const hosts = new Set<string>()
-    const labels = new Set<string>()
-    for (const descriptor of workspaces.workspaces) {
-      const host = workspaceHost(descriptor)
-      if (host) hosts.add(host)
-      for (const label of descriptor.labels ?? []) labels.add(label)
-    }
-    const projects = workspaceProjectGroups(workspaces, showArchived).map((group) => ({
-      id: group.projectId,
-      name: group.name,
-    }))
-    return {
-      hosts: [...hosts].sort(),
-      projects,
-      labels: [...labels].sort(),
-    }
-  }, [workspaces, showArchived])
+  // The filterable catalog derives from the live store: the sorted union of
+  // hosts and labels plus the projects as grouped. The derivation is pure (see
+  // workspaceCatalog in the seam) so it stays testable alongside the store.
+  const catalog = useMemo(() => workspaceCatalog(workspaces, showArchived), [workspaces, showArchived])
   // Both group modes collapse to one joined shape the render loop walks: a
   // key (project id or status), a name, and its rows. Status groups carry a
   // fixed aggregate status for their pill since every row shares it.

--- a/chrome/chrome.tsx
+++ b/chrome/chrome.tsx
@@ -7,7 +7,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import React, { useMemo, useState } from 'react'
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@gpuix/react'
+import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger } from '@gpuix/react'
 import {
   DAEMON_URL,
   displayName,
@@ -25,7 +25,9 @@ import {
   workspaceActivityAt,
   workspaceDisplayName,
   workspaceProjectGroups,
+  workspaceStatusGroups,
   type WorkspaceAggregateStatus,
+  type WorkspaceStatusGroup,
   type WorkspaceStore,
 } from '../agent-directory/workspaces'
 import {
@@ -33,13 +35,25 @@ import {
   workspaceRowTitle,
   type MetaTone,
   type WorkspaceMetaChecks,
+  type WorkspaceMetaConfig,
   type WorkspaceMetaItem,
   type WorkspaceMetaTrailing,
 } from '../agent-directory/workspace-meta'
 import {
+  hasActiveFilters,
+  labelColor,
+  UNLABELLED_LABEL,
+  workspaceHost,
+  workspaceMatchesFilters,
+  type WorkspaceFilters,
+} from '../agent-directory/display-preferences'
+import {
+  directoryGrouping,
   showArchivedAgents,
   showArchivedWorkspaces,
   useAppState,
+  workspaceFilters,
+  workspaceMetaConfig,
   type AppStore,
 } from '../app-state'
 import { C, SIDEBAR_WIDTH, TITLEBAR_HEIGHT, TRAFFIC_LIGHT_CLEARANCE } from './theme'
@@ -296,25 +310,85 @@ function ViewSection({ label }: { label: string }) {
 }
 
 /**
- * The sidebar's display-preferences popover, mirroring Paseo's: one trigger in
- * the section header and visibility toggles under Show. The directory itself
- * always renders as collapsible project groups of workspaces, so there is no
- * grouping choice anymore.
+ * The sidebar's display-preferences popover, mirroring Paseo's: grouping,
+ * the Show page (meta-line slot toggles + checks/trailing/title radios) and
+ * the host / project / label filters. Every choice persists via app-state and
+ * takes effect immediately. @gpuix/react's Select has no nested submenu, so
+ * the checks options render inline as their own section.
  */
 function ViewPreferencesMenu({
+  grouping,
+  onGroupingChange,
   showArchived,
   onShowArchivedChange,
   showArchivedAgents,
   onShowArchivedAgentsChange,
+  meta,
+  onMetaChange,
+  filters,
+  onFiltersChange,
+  catalog,
 }: {
+  grouping: 'status' | 'project'
+  onGroupingChange: (value: 'status' | 'project') => void
   showArchived: boolean
   onShowArchivedChange: (show: boolean) => void
   showArchivedAgents: boolean
   onShowArchivedAgentsChange: (show: boolean) => void
+  meta: WorkspaceMetaConfig
+  onMetaChange: (config: WorkspaceMetaConfig) => void
+  filters: WorkspaceFilters
+  onFiltersChange: (filters: WorkspaceFilters) => void
+  /** Filterable values discovered from the store, for the filter lists. */
+  catalog: { hosts: string[]; projects: { id: string; name: string }[]; labels: string[] }
 }) {
+  const slotToggle = (slot: keyof WorkspaceMetaConfig['slots']) => {
+    onMetaChange({ ...meta, slots: { ...meta.slots, [slot]: !meta.slots[slot] } })
+  }
+  const toggleLabel = (label: string) => {
+    const labels = filters.labels.includes(label)
+      ? filters.labels.filter((item) => item !== label)
+      : [...filters.labels, label]
+    onFiltersChange({ ...filters, labels })
+  }
+  const hasFilter = filters.hosts.length > 0 || filters.projects.length > 0 || filters.labels.length > 0
+
   const runChoice = (choice: string) => {
-    if (choice === 'show:archived') onShowArchivedChange(!showArchived)
-    if (choice === 'show:archived-agents') onShowArchivedAgentsChange(!showArchivedAgents)
+    if (choice === 'group:project') onGroupingChange('project')
+    else if (choice === 'group:status') onGroupingChange('status')
+    else if (choice === 'show:archived') onShowArchivedChange(!showArchived)
+    else if (choice === 'show:archived-agents') onShowArchivedAgentsChange(!showArchivedAgents)
+    else if (choice.startsWith('slot:')) {
+      const slot = choice.slice('slot:'.length) as keyof WorkspaceMetaConfig['slots']
+      slotToggle(slot)
+    } else if (choice.startsWith('checks:')) {
+      const mode = choice.slice('checks:'.length) as WorkspaceMetaConfig['checksMode']
+      onMetaChange({ ...meta, checksMode: mode })
+    } else if (choice.startsWith('trailing:')) {
+      const trailing = choice.slice('trailing:'.length) as WorkspaceMetaConfig['trailing']
+      onMetaChange({ ...meta, trailing })
+    } else if (choice.startsWith('title:')) {
+      const titleSource = choice.slice('title:'.length) as WorkspaceMetaConfig['titleSource']
+      onMetaChange({ ...meta, titleSource })
+    } else if (choice.startsWith('host:')) {
+      const host = choice.slice('host:'.length)
+      onFiltersChange({
+        ...filters,
+        hosts: filters.hosts.includes(host) ? filters.hosts.filter((item) => item !== host) : [...filters.hosts, host],
+      })
+    } else if (choice.startsWith('project:')) {
+      const projectId = choice.slice('project:'.length)
+      onFiltersChange({
+        ...filters,
+        projects: filters.projects.includes(projectId)
+          ? filters.projects.filter((item) => item !== projectId)
+          : [...filters.projects, projectId],
+      })
+    } else if (choice.startsWith('label:')) {
+      toggleLabel(choice.slice('label:'.length))
+    } else if (choice === 'clear-filters') {
+      onFiltersChange({ hosts: [], projects: [], labels: [] })
+    }
   }
 
   return (
@@ -337,6 +411,108 @@ function ViewPreferencesMenu({
         <Icon name="listFilter" size={14} color={C.secondary} />
       </SelectTrigger>
       <SelectContent side="bottom" align="end" sideOffset={4} style={{ width: VIEW_MENU_WIDTH }}>
+        <ViewSection label="Group by" />
+        <SelectItem value="group:project" textValue="Project">
+          <ViewOption icon="folder" label="Project" selected={grouping === 'project'} />
+        </SelectItem>
+        <SelectItem value="group:status" textValue="Status">
+          <ViewOption icon="zap" label="Status" selected={grouping === 'status'} />
+        </SelectItem>
+        <SelectSeparator />
+
+        <ViewSection label="Show" />
+        <SelectItem value="slot:branch" textValue="Branch">
+          <ViewOption icon="gitBranch" label="Branch" selected={meta.slots.branch} />
+        </SelectItem>
+        <SelectItem value="slot:pullRequest" textValue="Pull request">
+          <ViewOption icon="gitPullRequest" label="Pull request" selected={meta.slots.pullRequest} />
+        </SelectItem>
+        <SelectItem value="slot:services" textValue="Services">
+          <ViewOption icon="zap" label="Services" selected={meta.slots.services} />
+        </SelectItem>
+        <SelectItem value="slot:project" textValue="Project name">
+          <ViewOption icon="folder" label="Project name" selected={meta.slots.project} />
+        </SelectItem>
+        <SelectItem value="slot:host" textValue="Host">
+          <ViewOption icon="laptop" label="Host" selected={meta.slots.host} />
+        </SelectItem>
+        <SelectItem value="slot:labels" textValue="Labels">
+          <ViewOption icon="tag" label="Labels" selected={meta.slots.labels} />
+        </SelectItem>
+        <SelectSeparator />
+
+        <ViewSection label="Checks" />
+        <SelectItem value="checks:iconText" textValue="Icon and text">
+          <ViewOption icon="check" label="Icon and text" selected={meta.checksMode === 'iconText'} />
+        </SelectItem>
+        <SelectItem value="checks:iconOnly" textValue="Icon only">
+          <ViewOption icon="check" label="Icon only" selected={meta.checksMode === 'iconOnly'} />
+        </SelectItem>
+        <SelectItem value="checks:hidden" textValue="Hidden">
+          <ViewOption icon="x" label="Hidden" selected={meta.checksMode === 'hidden'} />
+        </SelectItem>
+        <SelectSeparator />
+
+        <ViewSection label="Trailing slot" />
+        <SelectItem value="trailing:diffStat" textValue="Diff stats">
+          <ViewOption icon="file" label="Diff stats" selected={meta.trailing === 'diffStat'} />
+        </SelectItem>
+        <SelectItem value="trailing:activity" textValue="Last activity">
+          <ViewOption icon="rotateCcw" label="Last activity" selected={meta.trailing === 'activity'} />
+        </SelectItem>
+        <SelectSeparator />
+
+        <ViewSection label="Row title" />
+        <SelectItem value="title:title" textValue="Title">
+          <ViewOption icon="pencil" label="Title" selected={meta.titleSource === 'title'} />
+        </SelectItem>
+        <SelectItem value="title:branch" textValue="Branch name">
+          <ViewOption icon="gitBranch" label="Branch name" selected={meta.titleSource === 'branch'} />
+        </SelectItem>
+        <SelectSeparator />
+
+        {catalog.hosts.length > 1 && (
+          <>
+            <ViewSection label="Host" />
+            {catalog.hosts.map((host) => (
+              <SelectItem key={host} value={`host:${host}`} textValue={host}>
+                <ViewOption icon="laptop" label={host} selected={filters.hosts.includes(host)} />
+              </SelectItem>
+            ))}
+            <SelectSeparator />
+          </>
+        )}
+
+        {catalog.projects.length > 1 && (
+          <>
+            <ViewSection label="Project" />
+            {catalog.projects.map((project) => (
+              <SelectItem key={project.id} value={`project:${project.id}`} textValue={project.name}>
+                <ViewOption icon="folder" label={project.name} selected={filters.projects.includes(project.id)} />
+              </SelectItem>
+            ))}
+            <SelectSeparator />
+          </>
+        )}
+
+        {catalog.labels.length > 0 && (
+          <>
+            <ViewSection label="Label" />
+            {catalog.labels.map((label) => (
+              <SelectItem key={label} value={`label:${label}`} textValue={label}>
+                <LabelOption label={label} selected={filters.labels.includes(label)} />
+              </SelectItem>
+            ))}
+            <SelectItem value={`label:${UNLABELLED_LABEL}`} textValue="Unlabelled">
+              <LabelOption label="Unlabelled" unlabelled selected={filters.labels.includes(UNLABELLED_LABEL)} />
+            </SelectItem>
+            <SelectItem value="clear-filters" textValue="Clear filter">
+              <ViewOption icon="x" label="Clear filter" selected={hasFilter} />
+            </SelectItem>
+            <SelectSeparator />
+          </>
+        )}
+
         <ViewSection label="Show" />
         <SelectItem value="show:archived" textValue="Archived workspaces">
           <ViewOption icon="archive" label="Archived workspaces" selected={showArchived} />
@@ -346,6 +522,46 @@ function ViewPreferencesMenu({
         </SelectItem>
       </SelectContent>
     </Select>
+  )
+}
+
+/**
+ * A filter option whose leading dot carries the label's deterministic color.
+ * Unlabelled renders a hollow dot so it reads as "nothing" rather than a color.
+ */
+function LabelOption({ label, selected, unlabelled }: { label: string; selected: boolean; unlabelled?: boolean }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        width: '100%',
+        paddingTop: 5,
+        paddingBottom: 5,
+        paddingLeft: 8,
+        paddingRight: 8,
+        borderRadius: 7,
+        hover: { backgroundColor: '#404040' },
+      }}
+    >
+      <div
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: 4,
+          flexShrink: 0,
+          backgroundColor: unlabelled ? '#00000000' : labelColor(label),
+          borderWidth: 1,
+          borderColor: C.ghost,
+        }}
+      />
+      <text style={{ fontSize: 12.5, fontWeight: 500, color: C.text, flexGrow: 1, minWidth: 0 }}>
+        {label}
+      </text>
+      {selected && <Icon name="check" size={11} color={C.secondary} />}
+    </div>
   )
 }
 
@@ -396,6 +612,7 @@ function AggregateStatusPill({ aggregate }: { aggregate: WorkspaceAggregateStatu
 
 function WorkspaceRow({
   descriptor,
+  config,
   active,
   busy,
   onSelect,
@@ -403,6 +620,8 @@ function WorkspaceRow({
   onArchive,
 }: {
   descriptor: WorkspaceDescriptor
+  /** The persisted meta-line configuration; defaults live in workspace-meta. */
+  config: WorkspaceMetaConfig
   active: boolean
   /** True while any lifecycle action on this row is in flight. */
   busy: boolean
@@ -417,7 +636,7 @@ function WorkspaceRow({
   // The meta line resolves the row's whole second line from the descriptor's
   // runtime fields; slots without backing data are absent, and a line with
   // nothing at all renders nothing rather than dead space.
-  const meta = workspaceMetaLine(descriptor)
+  const meta = workspaceMetaLine(descriptor, config)
 
   const startRename = () => {
     setNameDraft(workspaceDisplayName(descriptor))
@@ -502,7 +721,7 @@ function WorkspaceRow({
               flexGrow: 1,
             }}
           >
-            {workspaceRowTitle(descriptor)}
+            {workspaceRowTitle(descriptor, config)}
           </text>
           {hover ? (
             <OverflowMenu
@@ -884,6 +1103,15 @@ function ProjectGroupHeader({
   )
 }
 
+/** One sidebar row-group in the joined project/status shape the render loop walks. */
+interface SidebarGroup {
+  key: string
+  name: string
+  workspaces: WorkspaceDescriptor[]
+  /** Fixed for status groups (every row shares the bucket); null for project groups. */
+  fixedStatus: WorkspaceAggregateStatus | null
+}
+
 export function Sidebar({
   workspaces,
   agents,
@@ -931,6 +1159,9 @@ export function Sidebar({
   // The local state can't share the StateKey's name: the initializer would
   // read the destructured binding itself (TDZ), not the module-level key.
   const [revealArchivedAgents, setRevealArchivedAgents] = useAppState(appStore, showArchivedAgents)
+  const [grouping, setGrouping] = useAppState(appStore, directoryGrouping)
+  const [meta, setMeta] = useAppState(appStore, workspaceMetaConfig)
+  const [filters, setFilters] = useAppState(appStore, workspaceFilters)
   // Collapse state is view state; the store itself stays daemon-written. It is
   // component-local on purpose: toggling only re-renders the sidebar, so the
   // open conversation and the selected row — chat.tsx state this toggle never
@@ -938,7 +1169,46 @@ export function Sidebar({
   // project groups under a key no workspace can own.
   const [collapsedProjects, setCollapsedProjects] = useState<ReadonlySet<string>>(new Set())
   const ARCHIVED_GROUP_ID = '__archived__'
-  const groups = useMemo(() => workspaceProjectGroups(workspaces, showArchived), [workspaces, showArchived])
+  // The filterable catalog derives from the live store: hosts only when more
+  // than one exists, every project, and every label found across workspaces.
+  const catalog = useMemo(() => {
+    const hosts = new Set<string>()
+    const labels = new Set<string>()
+    for (const descriptor of workspaces.workspaces) {
+      const host = workspaceHost(descriptor)
+      if (host) hosts.add(host)
+      for (const label of descriptor.labels ?? []) labels.add(label)
+    }
+    const projects = workspaceProjectGroups(workspaces, showArchived).map((group) => ({
+      id: group.projectId,
+      name: group.name,
+    }))
+    return {
+      hosts: [...hosts].sort(),
+      projects,
+      labels: [...labels].sort(),
+    }
+  }, [workspaces, showArchived])
+  // Both group modes collapse to one joined shape the render loop walks: a
+  // key (project id or status), a name, and its rows. Status groups carry a
+  // fixed aggregate status for their pill since every row shares it.
+  const groups = useMemo<SidebarGroup[]>(() => {
+    if (grouping === 'status') {
+      return workspaceStatusGroups(workspaces, showArchived, filters).map((group) => ({
+        key: group.status,
+        name: group.label,
+        fixedStatus: { status: group.status, count: group.workspaces.length },
+        workspaces: group.workspaces,
+      }))
+    }
+    return workspaceProjectGroups(workspaces, showArchived, filters).map((group) => ({
+      key: group.projectId,
+      name: group.name,
+      fixedStatus: null,
+      workspaces: group.workspaces,
+    }))
+  }, [workspaces, showArchived, grouping, filters])
+  const filterEmpty = hasActiveFilters(filters) && groups.length === 0
   const archived = useMemo(
     () => (revealArchivedAgents ? sortAgents(agents.filter(isArchived)) : []),
     [agents, revealArchivedAgents],
@@ -1000,10 +1270,17 @@ export function Sidebar({
           Workspaces
         </text>
         <ViewPreferencesMenu
+          grouping={grouping}
+          onGroupingChange={setGrouping}
           showArchived={showArchived}
           onShowArchivedChange={setShowArchived}
           showArchivedAgents={revealArchivedAgents}
           onShowArchivedAgentsChange={setRevealArchivedAgents}
+          meta={meta}
+          onMetaChange={setMeta}
+          filters={filters}
+          onFiltersChange={setFilters}
+          catalog={catalog}
         />
       </div>
 
@@ -1019,19 +1296,23 @@ export function Sidebar({
         }}
       >
         {groups.map((group) => {
-          const collapsed = collapsedProjects.has(group.projectId)
-          // A collapsed project reduces to one aggregate pill over its
-          // members; expanded groups keep their per-workspace rows.
-          const aggregate = collapsed ? aggregateWorkspaceStatus(group.workspaces) : null
+          const collapsed = collapsedProjects.has(group.key)
+          // A collapsed group reduces to one aggregate status pill over its
+          // members; a status group's rows share a status, so the pill is the
+          // group's own status with its member count. Expanded groups keep
+          // their per-workspace rows.
+          const aggregate = collapsed
+            ? (group.fixedStatus ?? aggregateWorkspaceStatus(group.workspaces))
+            : null
           return (
             <div
-              key={group.projectId}
+              key={group.key}
               style={{ display: 'flex', flexDirection: 'column', paddingBottom: 10 }}
             >
               <ProjectGroupHeader
                 name={group.name}
                 collapsed={collapsed}
-                onToggle={() => toggleProject(group.projectId)}
+                onToggle={() => toggleProject(group.key)}
                 pill={aggregate && <AggregateStatusPill aggregate={aggregate} />}
               />
               {!collapsed &&
@@ -1039,6 +1320,7 @@ export function Sidebar({
                   <WorkspaceRow
                     key={descriptor.id}
                     descriptor={descriptor}
+                    config={meta}
                     active={descriptor.id === activeWorkspaceId}
                     busy={busyRows.some((row) => row.id === descriptor.id)}
                     onSelect={onSelect}
@@ -1049,7 +1331,21 @@ export function Sidebar({
             </div>
           )
         })}
-        {groups.length === 0 && (
+        {filterEmpty && (
+          <div style={{ padding: 14 }}>
+            <text style={{ fontSize: 12.5, lineHeight: 17, color: C.tertiary }}>
+              No workspaces match these filters.{" "}
+            </text>
+            <text
+              testId="clear-filters-action"
+              style={{ fontSize: 12.5, fontWeight: 500, color: C.accent, cursor: 'pointer' }}
+              onClick={() => setFilters({ hosts: [], projects: [], labels: [] })}
+            >
+              Clear filter
+            </text>
+          </div>
+        )}
+        {groups.length === 0 && !filterEmpty && (
           <div style={{ padding: 14 }}>
             <text style={{ fontSize: 12.5, lineHeight: 17, color: C.tertiary }}>
               No workspaces yet. Start one from the composer.

--- a/chrome/chrome.tsx
+++ b/chrome/chrome.tsx
@@ -10,7 +10,6 @@ import React, { useMemo, useState } from 'react'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@gpuix/react'
 import {
   DAEMON_URL,
-  basename,
   displayName,
   isArchived,
   relativeTime,
@@ -24,10 +23,17 @@ import {
   isArchivedWorkspace,
   workspaceActivityAt,
   workspaceDisplayName,
-  workspaceDirectory,
   workspaceProjectGroups,
   type WorkspaceStore,
 } from '../agent-directory/workspaces'
+import {
+  workspaceMetaLine,
+  workspaceRowTitle,
+  type MetaTone,
+  type WorkspaceMetaChecks,
+  type WorkspaceMetaItem,
+  type WorkspaceMetaTrailing,
+} from '../agent-directory/workspace-meta'
 import {
   showArchivedAgents,
   showArchivedWorkspaces,
@@ -54,6 +60,8 @@ import iconArrowRight from '../assets/icons/arrow-right.svg' with { type: 'file'
 import iconFolder from '../assets/icons/folder.svg' with { type: 'file' }
 import iconFile from '../assets/icons/file.svg' with { type: 'file' }
 import iconGitBranch from '../assets/icons/git-branch.svg' with { type: 'file' }
+import iconGitPullRequest from '../assets/icons/git-pull-request.svg' with { type: 'file' }
+import iconTag from '../assets/icons/tag.svg' with { type: 'file' }
 
 import iconLaptop from '../assets/icons/laptop.svg' with { type: 'file' }
 import iconLock from '../assets/icons/lock.svg' with { type: 'file' }
@@ -84,6 +92,8 @@ const ICONS = {
   folder: realAssetPath(iconFolder),
   file: realAssetPath(iconFile),
   gitBranch: realAssetPath(iconGitBranch),
+  gitPullRequest: realAssetPath(iconGitPullRequest),
+  tag: realAssetPath(iconTag),
   laptop: realAssetPath(iconLaptop),
   lock: realAssetPath(iconLock),
   list: realAssetPath(iconList),
@@ -372,12 +382,10 @@ function WorkspaceRow({
   const [renaming, setRenaming] = useState(false)
   const [nameDraft, setNameDraft] = useState('')
   const archived = isArchivedWorkspace(descriptor)
-  const directory = workspaceDirectory(descriptor)
-  const secondaryIcon = descriptor.workspaceKind === 'worktree' ? 'gitBranch' : 'folder'
-  const secondaryLabel =
-    descriptor.workspaceKind === 'worktree'
-      ? (descriptor.worktreeSlug ?? basename(directory))
-      : basename(directory)
+  // The meta line resolves the row's whole second line from the descriptor's
+  // runtime fields; slots without backing data are absent, and a line with
+  // nothing at all renders nothing rather than dead space.
+  const meta = workspaceMetaLine(descriptor)
 
   const startRename = () => {
     setNameDraft(workspaceDisplayName(descriptor))
@@ -462,7 +470,7 @@ function WorkspaceRow({
               flexGrow: 1,
             }}
           >
-            {workspaceDisplayName(descriptor)}
+            {workspaceRowTitle(descriptor)}
           </text>
           {hover ? (
             <OverflowMenu
@@ -486,23 +494,169 @@ function WorkspaceRow({
           ) : null}
         </div>
       )}
-      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 5, paddingLeft: 13 }}>
-        <Icon name={secondaryIcon} size={12.5} color={C.tertiary} />
-        <text
+      {(meta.items.length > 0 || meta.checks || meta.trailing) && (
+        <div
+          testId="workspace-row-meta"
+          style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 5, paddingLeft: 13 }}
+        >
+          {meta.items.map((item) => (
+            <MetaItemView key={item.kind} item={item} />
+          ))}
+          {meta.checks && <MetaChecksView checks={meta.checks} />}
+          <div style={{ flexGrow: 1 }} />
+          {meta.trailing && <MetaTrailingView trailing={meta.trailing} />}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Tone → palette; the pure meta seam stays theme-free, so the mapping lives here. */
+function metaToneColor(tone: MetaTone): string {
+  switch (tone) {
+    case 'ok':
+      return C.ok
+    case 'warn':
+      return C.warn
+    case 'danger':
+      return C.danger
+    case 'accent':
+      return C.accent
+    default:
+      return C.tertiary
+  }
+}
+
+/**
+ * One meta-line slot. The branch item is the only flexing one: it absorbs a
+ * runaway branch name with its own ellipsis so the rest of the line and the
+ * trailing slot keep their ground.
+ */
+function MetaItemView({ item }: { item: WorkspaceMetaItem }) {
+  switch (item.kind) {
+    case 'branch':
+      return (
+        <div
           style={{
-            fontSize: 13,
-            lineHeight: 15,
-            color: C.tertiary,
-            flexGrow: 1,
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 4,
+            flexShrink: 1,
             minWidth: 0,
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
           }}
         >
-          {secondaryLabel}
+          <Icon name="gitBranch" size={11.5} color={C.tertiary} />
+          <text
+            style={{
+              fontSize: 12,
+              lineHeight: 15,
+              color: C.tertiary,
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+              minWidth: 0,
+            }}
+          >
+            {item.text}
+          </text>
+          {item.dirty && <StatusDot color={C.warn} size={5} />}
+          {item.aheadBehind && (
+            <text style={{ fontSize: 11, lineHeight: 15, color: C.ghost, flexShrink: 0 }}>
+              {item.aheadBehind}
+            </text>
+          )}
+        </div>
+      )
+    case 'pullRequest':
+      return (
+        <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+          <Icon name="gitPullRequest" size={11.5} color={C.tertiary} />
+          <text style={{ fontSize: 12, lineHeight: 15, color: C.tertiary, whiteSpace: 'nowrap' }}>
+            {item.text}
+          </text>
+          {item.detail && (
+            <text style={{ fontSize: 11, lineHeight: 15, color: metaToneColor(item.tone), whiteSpace: 'nowrap' }}>
+              {item.detail}
+            </text>
+          )}
+        </div>
+      )
+    case 'services':
+      return (
+        <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+          <Icon name="zap" size={11.5} color={C.tertiary} />
+          <text style={{ fontSize: 12, lineHeight: 15, color: metaToneColor(item.tone), whiteSpace: 'nowrap' }}>
+            {item.text}
+          </text>
+        </div>
+      )
+    default: {
+      // Project, host, and labels are plain icon+text slots.
+      const icon: IconName = item.kind === 'project' ? 'folder' : item.kind === 'host' ? 'laptop' : 'tag'
+      return (
+        <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+          <Icon name={icon} size={11.5} color={C.tertiary} />
+          <text style={{ fontSize: 12, lineHeight: 15, color: C.tertiary, whiteSpace: 'nowrap' }}>
+            {item.text}
+          </text>
+        </div>
+      )
+    }
+  }
+}
+
+const CHECKS_ICON: Record<WorkspaceMetaChecks['status'], IconName> = {
+  success: 'check',
+  pending: 'rotateCcw',
+  failure: 'x',
+}
+
+const CHECKS_COLOR: Record<WorkspaceMetaChecks['status'], string> = {
+  success: C.ok,
+  pending: C.warn,
+  failure: C.danger,
+}
+
+/** The checks readout: one status-colored icon, plus its passed/total label when one resolved. */
+function MetaChecksView({ checks }: { checks: WorkspaceMetaChecks }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+      <Icon name={CHECKS_ICON[checks.status]} size={11.5} color={CHECKS_COLOR[checks.status]} />
+      {checks.label && (
+        <text style={{ fontSize: 11, lineHeight: 15, color: C.ghost, whiteSpace: 'nowrap' }}>
+          {checks.label}
         </text>
-      </div>
+      )}
     </div>
+  )
+}
+
+/**
+ * The right-aligned trailing slot. Diff stats mirror the TracksRow pill's
+ * `+n / -n` coloring with zero sides hidden; the activity alternative reads
+ * the same relative time the title line shows.
+ */
+function MetaTrailingView({ trailing }: { trailing: WorkspaceMetaTrailing }) {
+  if (trailing.kind === 'diffStat') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+        {trailing.additions > 0 && (
+          <text style={{ fontSize: 11.5, lineHeight: 15, fontWeight: 500, color: C.ok, whiteSpace: 'nowrap' }}>
+            {`+\u2060${trailing.additions}`}
+          </text>
+        )}
+        {trailing.deletions > 0 && (
+          <text style={{ fontSize: 11.5, lineHeight: 15, fontWeight: 500, color: C.danger, whiteSpace: 'nowrap' }}>
+            {`-\u2060${trailing.deletions}`}
+          </text>
+        )}
+      </div>
+    )
+  }
+  return (
+    <text style={{ fontSize: 11.5, lineHeight: 15, color: C.ghost, flexShrink: 0 }}>
+      {relativeTimeAt(trailing.at)}
+    </text>
   )
 }
 

--- a/chrome/chrome.tsx
+++ b/chrome/chrome.tsx
@@ -6,7 +6,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Select, SelectContent, SelectItem, SelectLabel, SelectSeparator, SelectTrigger } from '@gpuix/react'
 import {
   DAEMON_URL,
@@ -34,6 +34,7 @@ import {
   type WorkspaceStatusGroup,
   type WorkspaceStore,
 } from '../agent-directory/workspaces'
+import { visibleWorkspaceIds } from '../agent-directory/workspace-shortcuts'
 import {
   workspaceMetaLine,
   workspaceRowTitle,
@@ -1233,6 +1234,7 @@ export function Sidebar({
   navState,
   onNavBack,
   onNavForward,
+  onVisibleRowsChange,
 }: {
   /** The whole workspace directory, written only by the daemon subscription. */
   workspaces: WorkspaceStore
@@ -1262,6 +1264,8 @@ export function Sidebar({
   navState: { canBack: boolean; canForward: boolean }
   onNavBack: () => void
   onNavForward: () => void
+  /** Reports the current visible-walk-order of rows, for the jump shortcuts' handler. */
+  onVisibleRowsChange: (ids: string[]) => void
 }) {
   const [showArchived, setShowArchived] = useAppState(appStore, showArchivedWorkspaces)
   // The local state can't share the StateKey's name: the initializer would
@@ -1335,6 +1339,12 @@ export function Sidebar({
       return next
     })
   }
+  // The keyboard handler in chat.tsx reasons over the same rows the sidebar
+  // renders, so the walk order — sections minus collapsed projects — is
+  // reported up whenever the view or its collapse state changes.
+  useEffect(() => {
+    onVisibleRowsChange(visibleWorkspaceIds(groups, collapsedProjects))
+  }, [groups, collapsedProjects, onVisibleRowsChange])
 
   return (
     <div

--- a/chrome/chrome.tsx
+++ b/chrome/chrome.tsx
@@ -21,11 +21,13 @@ import {
   type WorkspaceDescriptor,
 } from '../daemon/paseo'
 import {
+  aggregateWorkspaceStatus,
   isArchivedWorkspace,
   workspaceActivityAt,
   workspaceDisplayName,
   workspaceDirectory,
   workspaceProjectGroups,
+  type WorkspaceAggregateStatus,
   type WorkspaceStore,
 } from '../agent-directory/workspaces'
 import {
@@ -352,6 +354,36 @@ export function workspaceStatusColor(status: WorkspaceDescriptor['status']): str
   }
 }
 
+/**
+ * A collapsed project's aggregate status pill: one dot in the most urgent
+ * bucket's color plus the count of workspaces sharing that bucket. Display
+ * only — the header row stays the click target for expanding.
+ */
+function AggregateStatusPill({ aggregate }: { aggregate: WorkspaceAggregateStatus }) {
+  return (
+    <div
+      testId="project-status-pill"
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 4,
+        height: 16,
+        paddingLeft: 6,
+        paddingRight: 6,
+        borderRadius: 8,
+        backgroundColor: C.item,
+        flexShrink: 0,
+      }}
+    >
+      <StatusDot color={workspaceStatusColor(aggregate.status)} size={6} />
+      <text style={{ fontSize: 10.5, fontWeight: 500, lineHeight: 14, color: C.tertiary }}>
+        {aggregate.count}
+      </text>
+    </div>
+  )
+}
+
 function WorkspaceRow({
   descriptor,
   active,
@@ -647,15 +679,21 @@ function ArchivedAgentRow({
   )
 }
 
-/** One collapsible project group header: chevron, name, click toggles its rows. */
+/**
+ * One collapsible project group header: chevron, name, and — while collapsed —
+ * the project's aggregate status pill. Clicking anywhere on it toggles.
+ */
 function ProjectGroupHeader({
   name,
   collapsed,
   onToggle,
+  pill,
 }: {
   name: string
   collapsed: boolean
   onToggle: () => void
+  /** Trailing adornment; the collapsed project's aggregate status pill. */
+  pill?: React.ReactNode
 }) {
   return (
     <div
@@ -687,6 +725,7 @@ function ProjectGroupHeader({
       >
         {name}
       </text>
+      {pill}
     </div>
   )
 }
@@ -738,9 +777,11 @@ export function Sidebar({
   // The local state can't share the StateKey's name: the initializer would
   // read the destructured binding itself (TDZ), not the module-level key.
   const [revealArchivedAgents, setRevealArchivedAgents] = useAppState(appStore, showArchivedAgents)
-  // Collapse state is view state; the store itself stays daemon-written. The
-  // Archived reveal section collapses like the project groups under a key no
-  // workspace can own.
+  // Collapse state is view state; the store itself stays daemon-written. It is
+  // component-local on purpose: toggling only re-renders the sidebar, so the
+  // open conversation and the selected row — chat.tsx state this toggle never
+  // touches — stay undisturbed. The Archived reveal section collapses like the
+  // project groups under a key no workspace can own.
   const [collapsedProjects, setCollapsedProjects] = useState<ReadonlySet<string>>(new Set())
   const ARCHIVED_GROUP_ID = '__archived__'
   const groups = useMemo(() => workspaceProjectGroups(workspaces, showArchived), [workspaces, showArchived])
@@ -823,30 +864,37 @@ export function Sidebar({
           paddingRight: 10,
         }}
       >
-        {groups.map((group) => (
-          <div
-            key={group.projectId}
-            style={{ display: 'flex', flexDirection: 'column', paddingBottom: 10 }}
-          >
-            <ProjectGroupHeader
-              name={group.name}
-              collapsed={collapsedProjects.has(group.projectId)}
-              onToggle={() => toggleProject(group.projectId)}
-            />
-            {!collapsedProjects.has(group.projectId) &&
-              group.workspaces.map((descriptor) => (
-                <WorkspaceRow
-                  key={descriptor.id}
-                  descriptor={descriptor}
-                  active={descriptor.id === activeWorkspaceId}
-                  busy={busyRows.some((row) => row.id === descriptor.id)}
-                  onSelect={onSelect}
-                  onRename={onRename}
-                  onArchive={onArchive}
-                />
-              ))}
-          </div>
-        ))}
+        {groups.map((group) => {
+          const collapsed = collapsedProjects.has(group.projectId)
+          // A collapsed project reduces to one aggregate pill over its
+          // members; expanded groups keep their per-workspace rows.
+          const aggregate = collapsed ? aggregateWorkspaceStatus(group.workspaces) : null
+          return (
+            <div
+              key={group.projectId}
+              style={{ display: 'flex', flexDirection: 'column', paddingBottom: 10 }}
+            >
+              <ProjectGroupHeader
+                name={group.name}
+                collapsed={collapsed}
+                onToggle={() => toggleProject(group.projectId)}
+                pill={aggregate && <AggregateStatusPill aggregate={aggregate} />}
+              />
+              {!collapsed &&
+                group.workspaces.map((descriptor) => (
+                  <WorkspaceRow
+                    key={descriptor.id}
+                    descriptor={descriptor}
+                    active={descriptor.id === activeWorkspaceId}
+                    busy={busyRows.some((row) => row.id === descriptor.id)}
+                    onSelect={onSelect}
+                    onRename={onRename}
+                    onArchive={onArchive}
+                  />
+                ))}
+            </div>
+          )
+        })}
         {groups.length === 0 && (
           <div style={{ padding: 14 }}>
             <text style={{ fontSize: 12.5, lineHeight: 17, color: C.tertiary }}>

--- a/layout/layout.test.ts
+++ b/layout/layout.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  allPaneIds,
+  activeLeaf,
+  findPane,
+  initialLayout,
+  leaf,
+  paneLeaves,
+  reduceLayout,
+  resetIdCounter,
+  type PaneEvent,
+} from './layout'
+
+/** Reduce events from the initial state with a fresh id counter. */
+function run(events: PaneEvent[]) {
+  resetIdCounter()
+  return events.reduce(reduceLayout, initialLayout())
+}
+
+describe('pane layout reducer', () => {
+  test('initial state is a single empty leaf with no active pane', () => {
+    resetIdCounter()
+    const state = initialLayout()
+    expect(state!.root.kind).toBe('leaf')
+    expect(paneLeaves(state!.root)).toHaveLength(1)
+    expect(state!.activePaneId).toBe('')
+    expect(paneLeaves(state!.root)[0]!.tabIds).toEqual([])
+  })
+
+  test('reset returns the empty single leaf', () => {
+    resetIdCounter()
+    const split = run([{ type: 'splitRight', paneId: 'p0' }])
+    expect(split!.root.kind).not.toBe('leaf')
+    const reset = reduceLayout(split, { type: 'reset' })
+    expect(reset!.root.kind).toBe('leaf')
+    expect(paneLeaves(reset!.root)).toHaveLength(1)
+  })
+
+  test('splitRight divides a single leaf into two panes side by side', () => {
+    resetIdCounter()
+    const state = run([{ type: 'splitRight', paneId: 'p0' }])
+    const root = state!.root
+    expect(root.kind).toBe('group')
+    if (root.kind === 'group') {
+      expect(root.direction).toBe('horizontal')
+      expect(root.children).toHaveLength(2)
+      expect(root.sizes).toEqual([0.5, 0.5])
+    }
+    expect(paneLeaves(state!.root).map((l) => l.id)).toEqual(['p0', 'p1'])
+    // The new pane gets focus.
+    expect(state!.activePaneId).toBe('p1')
+  })
+
+  test('splitDown divides a single leaf into two panes stacked', () => {
+    resetIdCounter()
+    const state = run([{ type: 'splitDown', paneId: 'p0' }])
+    const root = state!.root
+    expect(root.kind).toBe('group')
+    if (root.kind === 'group') {
+      expect(root.direction).toBe('vertical')
+      expect(root.children).toHaveLength(2)
+    }
+  })
+
+  test('splitting a leaf within a group keeps the group structure intact', () => {
+    resetIdCounter()
+    const split = run([{ type: 'splitRight', paneId: 'p0' }])
+    // Split p0 again (it is still the left child).
+    const state = reduceLayout(split, { type: 'splitRight', paneId: 'p0' })
+    const leaves = paneLeaves(state!.root)
+    expect(leaves.map((l) => l.id)).toEqual(['p0', 'p2', 'p1'])
+    expect(state!.activePaneId).toBe('p2')
+  })
+
+  test('split is a no-op for an unknown pane id', () => {
+    resetIdCounter()
+    const before = initialLayout()
+    const state = reduceLayout(before, { type: 'splitRight', paneId: 'nope' })
+    // The unknown split leaves the state untouched (same object) and single-leaf.
+    expect(state).toBe(before)
+    expect(paneLeaves(state!.root)).toHaveLength(1)
+  })
+
+  test('assignTab places a tab into the active pane and focuses it', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' }, // active = p1
+      { type: 'assignTab', tabId: 't0' }, // goes into p1 (active)
+    ])
+    expect(findPane(state!.root, 'p1')!.tabIds).toEqual(['t0'])
+    expect(findPane(state!.root, 'p1')!.focusedTabId).toBe('t0')
+    expect(state!.activePaneId).toBe('p1')
+  })
+
+  test('assignTab to a named pane (not the active one)', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' }, // p0, p1; active=p1
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+    ])
+    expect(findPane(state!.root, 'p0')!.tabIds).toEqual(['t0'])
+    expect(findPane(state!.root, 'p1')!.tabIds).toEqual([])
+    expect(state!.activePaneId).toBe('p0')
+  })
+
+  test('moving a tab across panes reorders correctly', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' }, // p0, p1; active p1
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p0' },
+      { type: 'focusPane', paneId: 'p0' },
+    ])
+    expect(findPane(state!.root, 'p0')!.tabIds).toEqual(['t0', 't1'])
+    // Move t0 from p0 to p1.
+    const moved = reduceLayout(state, { type: 'moveTab', tabId: 't0', fromPaneId: 'p0', toPaneId: 'p1', index: 0 })
+    expect(findPane(moved!.root, 'p0')!.tabIds).toEqual(['t1'])
+    expect(findPane(moved!.root, 'p1')!.tabIds).toEqual(['t0'])
+    expect(findPane(moved!.root, 'p1')!.focusedTabId).toBe('t0')
+    expect(moved!.activePaneId).toBe('p1')
+  })
+
+  test('moveTab preserves a source-focused hand-off when the moved tab was focused', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't2', paneId: 'p0' },
+      { type: 'focusPane', paneId: 'p0' },
+    ])
+    // p0 focus on t2 (last assigned).
+    expect(findPane(state!.root, 'p0')!.focusedTabId).toBe('t2')
+    const moved = reduceLayout(state, { type: 'moveTab', tabId: 't2', fromPaneId: 'p0', toPaneId: 'p1', index: 0 })
+    // Source focus falls to the first remaining.
+    expect(findPane(moved!.root, 'p0')!.focusedTabId).toBe('t0')
+    expect(findPane(moved!.root, 'p1')!.focusedTabId).toBe('t2')
+  })
+
+  test('moveTab is ignored for an absent tab or unknown pane', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' },
+      { type: 'moveTab', tabId: 'nope', fromPaneId: 'p0', toPaneId: 'p1' },
+    ])
+    expect(findPane(state!.root, 'p0')!.tabIds).toEqual([])
+    expect(findPane(state!.root, 'p1')!.tabIds).toEqual([])
+  })
+
+  test('focusPane sets the active pane', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' }, // active p1
+      { type: 'focusPane', paneId: 'p0' },
+    ])
+    expect(state!.activePaneId).toBe('p0')
+  })
+
+  test('focusTab focuses a tab within its pane and activates the pane', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p0' },
+      { type: 'focusPane', paneId: 'p1' }, // active elsewhere
+      { type: 'focusTab', paneId: 'p0', tabId: 't0' },
+    ])
+    expect(findPane(state!.root, 'p0')!.focusedTabId).toBe('t0')
+    expect(state!.activePaneId).toBe('p0')
+  })
+
+  test('focusNextPane / focusPrevPane cycle in both directions', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' }, // p0,p1; active=p1
+      { type: 'focusPane', paneId: 'p0' }, // active=p0
+      { type: 'splitDown', paneId: 'p1' }, // p0,p1,p2; active=p2
+    ])
+    const leaves = paneLeaves(state!.root)
+    expect(leaves.map((l) => l.id)).toEqual(['p0', 'p1', 'p2'])
+    expect(state!.activePaneId).toBe('p2')
+    expect(reduceLayout(state, { type: 'focusNextPane' })!.activePaneId).toBe('p0')
+    const next2 = reduceLayout(reduceLayout(state, { type: 'focusNextPane' }), { type: 'focusNextPane' })
+    expect(next2!.activePaneId).toBe('p1')
+    // Prev wraps p2 -> p1.
+    expect(reduceLayout(state, { type: 'focusPrevPane' })!.activePaneId).toBe('p1')
+    const prev2 = reduceLayout(reduceLayout(state, { type: 'focusPrevPane' }), { type: 'focusPrevPane' })
+    expect(prev2!.activePaneId).toBe('p0')
+  })
+
+  test('focus cycle is inert with a single pane', () => {
+    resetIdCounter()
+    const state = initialLayout()
+    expect(reduceLayout(state, { type: 'focusNextPane' })).toBe(state)
+    expect(reduceLayout(state, { type: 'focusPrevPane' })).toBe(state)
+  })
+
+  test('focusNextTab / focusPrevTab cycle within the active pane', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't0', paneId: 'p1' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p1' },
+      { type: 'assignTab', tabId: 't2', paneId: 'p1' },
+    ])
+    expect(findPane(state!.root, 'p1')!.tabIds).toEqual(['t0', 't1', 't2'])
+    expect(findPane(state!.root, 'p1')!.focusedTabId).toBe('t2')
+    const next = reduceLayout(state, { type: 'focusNextTab' })
+    expect(findPane(next!.root, 'p1')!.focusedTabId).toBe('t0')
+    const next2 = reduceLayout(next, { type: 'focusNextTab' })
+    expect(findPane(next2!.root, 'p1')!.focusedTabId).toBe('t1')
+    const next3 = reduceLayout(next2, { type: 'focusNextTab' })
+    expect(findPane(next3!.root, 'p1')!.focusedTabId).toBe('t2')
+    const prev = reduceLayout(state, { type: 'focusPrevTab' })
+    expect(findPane(prev!.root, 'p1')!.focusedTabId).toBe('t1')
+  })
+
+  test('removeTab removes a tab from the tree and collapses an emptied pane', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' }, // p0, p1
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p1' },
+    ])
+    // Remove t1 (last tab of p1 -> p1 empties and the workspace collapses to a
+    // single pane, which returns null for the default non-persisted layout).
+    const removed = reduceLayout(state, { type: 'removeTab', tabId: 't1' })
+    expect(removed).toBeNull()
+  })
+
+  test('closing tabs down to nothing never strands an empty root pane', () => {
+    resetIdCounter()
+    // Three panes, each with one tab. Remove all tabs: each emptied pane gets
+    // folded until a single leaf remains, then null.
+    let state = run([
+      { type: 'splitRight', paneId: 'p0' }, // p0,p1
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p1' },
+    ])
+    state = reduceLayout(state!, { type: 'splitDown', paneId: 'p1' }) // p0,p1,p2
+    state = reduceLayout(state!, { type: 'assignTab', tabId: 't2', paneId: 'p2' })
+    expect(paneLeaves(state!.root)).toHaveLength(3)
+    state = reduceLayout(state!, { type: 'removeTab', tabId: 't0' })
+    state = reduceLayout(state!, { type: 'removeTab', tabId: 't1' })
+    state = reduceLayout(state!, { type: 'removeTab', tabId: 't2' })
+    expect(state).toBeNull()
+  })
+
+  test('removeTab keeps a non-empty pane and collapses only the emptied sibling', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' }, // p0,p1
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't2', paneId: 'p1' },
+      { type: 'splitDown', paneId: 'p0' }, // p0,p2,p1
+      { type: 'assignTab', tabId: 't3', paneId: 'p2' },
+    ])
+    // Structure: horizontal[p0,p1] where p1 was replaced... actually p0 split.
+    // Just verify removing t2 (only tab in p1) collapses p1 but leaves the rest.
+    const removed = reduceLayout(state!, { type: 'removeTab', tabId: 't2' })
+    expect(removed).not.toBeNull()
+    const ids = paneLeaves(removed!.root).map((l) => l.id)
+    expect(ids).toContain('p0')
+    expect(ids).toContain('p2')
+  })
+
+  test('closePane removes a pane and collapses its siblings', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' }, // p0,p1
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p1' },
+      { type: 'splitDown', paneId: 'p1' }, // p0,p1,p2
+      { type: 'assignTab', tabId: 't2', paneId: 'p2' },
+    ])
+    expect(paneLeaves(state!.root).map((l) => l.id)).toEqual(['p0', 'p1', 'p2'])
+    // Close the middle pane p1, which holds t1.
+    const closed = reduceLayout(state!, { type: 'closePane', paneId: 'p1' })
+    expect(closed).not.toBeNull()
+    // Now p0,p2 remain in a group.
+    expect(paneLeaves(closed!.root).map((l) => l.id)).toEqual(['p0', 'p2'])
+    expect(findPane(closed!.root, 'p0')!.tabIds).toEqual(['t0'])
+    expect(findPane(closed!.root, 'p2')!.tabIds).toEqual(['t2'])
+  })
+
+  test('closePane on the only pane returns the default null layout', () => {
+    resetIdCounter()
+    expect(reduceLayout(initialLayout(), { type: 'closePane', paneId: 'p0' })).toBeNull()
+  })
+
+  test('reorderTab moves a tab within its pane', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't0', paneId: 'p1' },
+      { type: 'assignTab', tabId: 't1', paneId: 'p1' },
+      { type: 'assignTab', tabId: 't2', paneId: 'p1' },
+    ])
+    expect(findPane(state!.root, 'p1')!.tabIds).toEqual(['t0', 't1', 't2'])
+    const reordered = reduceLayout(state!, { type: 'reorderTab', paneId: 'p1', tabId: 't2', toIndex: 0 })
+    expect(findPane(reordered!.root, 'p1')!.tabIds).toEqual(['t2', 't0', 't1'])
+  })
+
+  test('degenerate: deep nesting does not lose panes', () => {
+    resetIdCounter()
+    let state = run([
+      { type: 'splitRight', paneId: 'p0' },
+      { type: 'splitDown', paneId: 'p1' },
+      { type: 'splitRight', paneId: 'p2' },
+      { type: 'splitDown', paneId: 'p3' },
+    ])
+    expect(paneLeaves(state!.root)).toHaveLength(5)
+    // Each split targets the previously-created leaf; all five survive.
+    expect(paneLeaves(state!.root).map((l) => l.id)).toEqual(['p0', 'p1', 'p2', 'p3', 'p4'])
+    // Focus cycles stably across all panes.
+    let current = state
+    for (let i = 0; i < 6; i++) {
+      current = reduceLayout(current!, { type: 'focusNextPane' })
+    }
+    expect(current!.activePaneId).toBe('p0')
+  })
+
+  test('paneLeaves and allPaneIds agree on depth-first order', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' },
+      { type: 'splitDown', paneId: 'p1' },
+    ])
+    expect(paneLeaves(state!.root).map((l) => l.id)).toEqual(allPaneIds(state!.root))
+  })
+
+  test('activeLeaf reflects the active pane', () => {
+    resetIdCounter()
+    const state = run([
+      { type: 'splitRight', paneId: 'p0' },
+      { type: 'assignTab', tabId: 't0', paneId: 'p0' },
+      { type: 'focusTab', paneId: 'p0', tabId: 't0' },
+    ])
+    expect(activeLeaf(state!)!.id).toBe('p0')
+    expect(state!.activePaneId).toBe('p0')
+  })
+
+  test('leaf() factory produces a pane leaf with the right shape', () => {
+    resetIdCounter()
+    const l = leaf(['t0'], 't0')
+    expect(l).toEqual({ kind: 'leaf', id: 'p0', tabIds: ['t0'], focusedTabId: 't0' })
+  })
+})

--- a/layout/layout.ts
+++ b/layout/layout.ts
@@ -1,0 +1,477 @@
+/**
+ * Pane layout tree: split geometry for the workspace screen.
+ *
+ * The workspace screen can be divided into panes, each showing its own ordered
+ * tabs (drawn from the workspace's #46 tab strip) with one focused tab. The
+ * layout is a binary tree: group nodes split horizontally (left-right) or
+ * vertically (top-bottom) with normalized sizes, leaf nodes hold tab
+ * references. A single-pane workspace (the default) has no tree at all —
+ * the layout is `null` until the user splits, at which point persistence
+ * kicks in.
+ *
+ * All tree geometry lives in this pure reducer: initialState, an event union,
+ * reduceLayout(state, event), and pure selectors. The hook only translates
+ * user gestures (keyboard, pointer) into events and drives persistence via the
+ * app-state store. No rendering tests; this module is testable in isolation.
+ *
+ * **Integration with #46 tabs:** the pane tree does NOT own tabs — the workspace
+ * tab reducer (tabs/tabs.ts) does. Each leaf pane carries an ordered list of
+ * `tabId` strings that are the same ids the #46 reducer produces. When a tab is
+ * closed via #46, a `removeTab` event here cleans up references. When a pane is
+ * split, the caller decides which tabIds to place in the new pane (typically
+ * none — the new pane starts empty and the user moves tabs into it).
+ */
+
+// ---- types -----------------------------------------------------------------
+
+export interface PaneLeaf {
+  kind: 'leaf'
+  id: string
+  /** Ordered tab ids from the #46 tab model; the focused tab is tracked separately. */
+  tabIds: string[]
+  /** Which tab in this pane has focus; null when the pane has no tabs. */
+  focusedTabId: string | null
+}
+
+export interface PaneGroup {
+  kind: 'group'
+  id: string
+  /** The split axis: horizontal = left-right, vertical = top-bottom. */
+  direction: 'horizontal' | 'vertical'
+  /** Child nodes, left-to-right (horizontal) or top-to-bottom (vertical). */
+  children: PaneNode[]
+  /** Normalized sizes; same length as `children`, sums to ~1. */
+  sizes: number[]
+}
+
+export type PaneNode = PaneLeaf | PaneGroup
+
+export interface PaneLayout {
+  root: PaneNode
+  /** The pane currently receiving keyboard input. */
+  activePaneId: string
+}
+
+/** null = default single-pane layout (not persisted until the user splits). */
+export type PaneLayoutState = PaneLayout | null
+
+// ---- state -----------------------------------------------------------------
+
+let _paneSeq = 0
+let _groupSeq = 0
+
+function nextPaneId(): string {
+  return `p${_paneSeq++}`
+}
+
+function nextGroupId(): string {
+  return `g${_groupSeq++}`
+}
+
+export function resetIdCounter(): void {
+  _paneSeq = 0
+  _groupSeq = 0
+}
+
+export function leaf(tabIds: string[] = [], focusedTabId: string | null = null): PaneLeaf {
+  return { kind: 'leaf', id: nextPaneId(), tabIds, focusedTabId }
+}
+
+/** The default state: a single empty leaf. */
+export function initialLayout(): PaneLayoutState {
+  return { root: leaf(), activePaneId: '' }
+}
+
+// ---- selectors --------------------------------------------------------------
+
+/** Collects leaf nodes in depth-first order. */
+export function paneLeaves(node: PaneNode): PaneLeaf[] {
+  if (node.kind === 'leaf') return [node]
+  return node.children.flatMap(paneLeaves)
+}
+
+/** Returns the leaf with the given id, or null. */
+export function findPane(root: PaneNode, id: string): PaneLeaf | null {
+  if (root.kind === 'leaf') return root.id === id ? root : null
+  for (const child of root.children) {
+    const found = findPane(child, id)
+    if (found) return found
+  }
+  return null
+}
+
+/** The active leaf pane (the one the user is interacting with). */
+export function activeLeaf(layout: PaneLayout): PaneLeaf | null {
+  return findPane(layout.root, layout.activePaneId)
+}
+
+/** All pane ids in depth-first order. */
+export function allPaneIds(root: PaneNode): string[] {
+  if (root.kind === 'leaf') return [root.id]
+  return root.children.flatMap(allPaneIds)
+}
+
+/** Ordered tab ids for a specific pane. */
+export function paneTabIds(root: PaneNode, paneId: string): string[] {
+  return findPane(root, paneId)?.tabIds ?? []
+}
+
+/** The focused tab id of the active pane, or null. */
+export function activePaneTabId(layout: PaneLayout): string | null {
+  return activeLeaf(layout)?.focusedTabId ?? null
+}
+
+// ---- tree helpers -----------------------------------------------------------
+
+/** Normalize a sizes array so it sums to exactly 1. */
+function normalize(sizes: number[]): number[] {
+  const total = sizes.reduce((a, b) => a + b, 0)
+  if (total === 0) return sizes.map(() => 1 / sizes.length)
+  return sizes.map((s) => s / total)
+}
+
+/** Recursively search for a node by id. */
+function findNode(node: PaneNode, id: string): PaneNode | null {
+  if (node.kind === 'leaf') return node.id === id ? node : null
+  if (node.id === id) return node
+  for (const child of node.children) {
+    const found = findNode(child, id)
+    if (found) return found
+  }
+  return null
+}
+
+/** Find the direct parent group containing a child with exactly the given id. */
+function findParent(node: PaneNode, childId: string): { group: PaneGroup; index: number } | null {
+  if (node.kind === 'leaf') return null
+  const direct = node.children.findIndex((child) => child.id === childId)
+  if (direct >= 0) return { group: node, index: direct }
+  for (const child of node.children) {
+    const found = findParent(child, childId)
+    if (found) return found
+  }
+  return null
+}
+
+/** Clone a pane node deeply enough for pure reducer use. */
+function cloneNode(node: PaneNode): PaneNode {
+  if (node.kind === 'leaf') {
+    return { ...node, tabIds: [...node.tabIds] }
+  }
+  return {
+    ...node,
+    children: node.children.map(cloneNode),
+    sizes: [...node.sizes],
+  }
+}
+
+/** Split a leaf in the cloned tree into a group of two leaves. */
+function splitLeafInPlace(
+  root: PaneNode,
+  targetId: string,
+  direction: 'horizontal' | 'vertical',
+  newPane: PaneLeaf,
+): PaneNode {
+  const parent = findParent(root, targetId)
+  const target = findPane(root, targetId)
+  if (!target) return root
+
+  const group: PaneGroup = {
+    kind: 'group',
+    id: nextGroupId(),
+    direction,
+    children: [{ ...target, tabIds: [...target.tabIds] }, newPane],
+    sizes: [0.5, 0.5],
+  }
+
+  if (!parent) {
+    // target is the root leaf
+    return group
+  }
+
+  const { group: parentNode, index } = parent
+  parentNode.children[index] = group
+  parentNode.sizes[index] = parentNode.sizes[index]! / 2
+  parentNode.sizes.splice(index + 1, 0, parentNode.sizes[index]!)
+  return root
+}
+
+/** Collapse unnecessary single-child groups. */
+function collapseGroups(node: PaneNode): PaneNode {
+  if (node.kind === 'leaf') return node
+  if (node.children.length === 1) return collapseGroups(node.children[0]!)
+  node.children = node.children.map(collapseGroups)
+  return node
+}
+
+// ---- validation (for persistence) -------------------------------------------
+
+function validSizes(sizes: unknown): sizes is number[] {
+  if (!Array.isArray(sizes)) return false
+  return sizes.every((s) => typeof s === 'number' && Number.isFinite(s) && s > 0)
+}
+
+/** Deep-validates a pane node as read back from storage; undefined when stale. */
+export function validatePaneNode(raw: unknown): PaneNode | undefined {
+  if (raw == null || typeof raw !== 'object') return undefined
+  const node = raw as Record<string, unknown>
+  if (node.kind === 'leaf') {
+    if (!Array.isArray(node.tabIds) || !node.tabIds.every((t) => typeof t === 'string')) return undefined
+    const focused = node.focusedTabId
+    if (focused != null && typeof focused !== 'string') return undefined
+    if (typeof node.id !== 'string') return undefined
+    return {
+      kind: 'leaf',
+      id: node.id,
+      tabIds: [...node.tabIds],
+      focusedTabId: typeof focused === 'string' ? focused : null,
+    }
+  }
+  if (node.kind === 'group') {
+    if (node.direction !== 'horizontal' && node.direction !== 'vertical') return undefined
+    if (!Array.isArray(node.children) || node.children.length < 2) return undefined
+    if (!validSizes(node.sizes) || node.sizes.length !== node.children.length) return undefined
+    if (typeof node.id !== 'string') return undefined
+    const children: PaneNode[] = []
+    for (const child of node.children) {
+      const parsed = validatePaneNode(child)
+      if (!parsed) return undefined
+      children.push(parsed)
+    }
+    return { kind: 'group', id: node.id, direction: node.direction, children, sizes: [...node.sizes] }
+  }
+  return undefined
+}
+
+/** Deep-validates a persisted pane layout; undefined when stale. */
+export function validatePaneLayout(raw: unknown): PaneLayout | undefined {
+  if (raw == null || typeof raw !== 'object') return undefined
+  const value = raw as Record<string, unknown>
+  const root = validatePaneNode(value.root)
+  if (!root) return undefined
+  if (typeof value.activePaneId !== 'string') return undefined
+  // The active pane must actually exist.
+  if (!findPane(root, value.activePaneId)) return undefined
+  return { root, activePaneId: value.activePaneId }
+}
+
+// ---- events ----------------------------------------------------------------
+
+export type PaneEvent =
+  | { type: 'reset' }
+  /** Split a pane's right half. */
+  | { type: 'splitRight'; paneId: string; newPaneId?: string }
+  /** Split a pane's bottom half. */
+  | { type: 'splitDown'; paneId: string; newPaneId?: string }
+  /** Close an entire pane (redistributes size to siblings). */
+  | { type: 'closePane'; paneId: string }
+  /** Move a tab from one pane to another (inserts at a position). */
+  | { type: 'moveTab'; tabId: string; fromPaneId: string; toPaneId: string; index?: number }
+  /** Ensure a tab exists in a pane (default the active pane), focusing it; used when a tab opens. */
+  | { type: 'assignTab'; tabId: string; paneId?: string }
+  /** Focus a pane. */
+  | { type: 'focusPane'; paneId: string }
+  /** Focus a tab within its pane. */
+  | { type: 'focusTab'; paneId: string; tabId: string }
+  /** Cycle focus to the next pane (wrapping). */
+  | { type: 'focusNextPane' }
+  /** Cycle focus to the previous pane (wrapping). */
+  | { type: 'focusPrevPane' }
+  /** Cycle focus to the next tab in the active pane (wrapping). */
+  | { type: 'focusNextTab' }
+  /** Cycle focus to the previous tab in the active pane (wrapping). */
+  | { type: 'focusPrevTab' }
+  /** A tab was closed via #46; clean up references. */
+  | { type: 'removeTab'; tabId: string }
+  /** Reorder a tab within its pane. */
+  | { type: 'reorderTab'; paneId: string; tabId: string; toIndex: number }
+
+// ---- reducer ---------------------------------------------------------------
+
+export function reduceLayout(state: PaneLayoutState, event: PaneEvent): PaneLayoutState {
+  switch (event.type) {
+    case 'reset':
+      return initialLayout()
+
+    case 'splitRight': {
+      const current = state ?? initialLayout()
+      const target = findPane(current.root, event.paneId)
+      if (!target) return state
+      const newId = event.newPaneId ?? nextPaneId()
+      const newPane: PaneLeaf = { kind: 'leaf', id: newId, tabIds: [], focusedTabId: null }
+      const root = splitLeafInPlace(cloneNode(current.root), event.paneId, 'horizontal', newPane)
+      return { root, activePaneId: newId }
+    }
+
+    case 'splitDown': {
+      const current = state ?? initialLayout()
+      const target = findPane(current.root, event.paneId)
+      if (!target) return state
+      const newId = event.newPaneId ?? nextPaneId()
+      const newPane: PaneLeaf = { kind: 'leaf', id: newId, tabIds: [], focusedTabId: null }
+      const root = splitLeafInPlace(cloneNode(current.root), event.paneId, 'vertical', newPane)
+      return { root, activePaneId: newId }
+    }
+
+    case 'moveTab': {
+      const current = state ?? initialLayout()
+      const fromPane = findPane(current.root, event.fromPaneId)
+      const toPane = findPane(current.root, event.toPaneId)
+      if (!fromPane || !toPane) return current
+      if (fromPane.tabIds.indexOf(event.tabId) < 0) return current
+      const root = cloneNode(current.root)
+      const src = findPane(root, event.fromPaneId)!
+      const dst = findPane(root, event.toPaneId)!
+      src.tabIds = src.tabIds.filter((id) => id !== event.tabId)
+      if (src.focusedTabId === event.tabId) {
+        src.focusedTabId = src.tabIds[0] ?? null
+      }
+      const insertAt = event.index ?? dst.tabIds.length
+      dst.tabIds.splice(insertAt, 0, event.tabId)
+      dst.focusedTabId = event.tabId
+      return { root, activePaneId: event.toPaneId }
+    }
+
+    case 'assignTab': {
+      const current = state ?? initialLayout()
+      const pane = event.paneId ? findPane(current.root, event.paneId) : activeLeaf(current)
+      if (!pane) return current
+      const root = cloneNode(current.root)
+      const target = event.paneId ? findPane(root, event.paneId)! : findPane(root, pane.id)!
+      if (!target.tabIds.includes(event.tabId)) target.tabIds.push(event.tabId)
+      target.focusedTabId = event.tabId
+      return { root, activePaneId: target.id }
+    }
+
+    case 'focusPane': {
+      const current = state ?? initialLayout()
+      if (!findPane(current.root, event.paneId)) return current
+      return { root: current.root, activePaneId: event.paneId }
+    }
+
+    case 'focusTab': {
+      const current = state ?? initialLayout()
+      const pane = findPane(current.root, event.paneId)
+      if (!pane || !pane.tabIds.includes(event.tabId)) return current
+      const root = cloneNode(current.root)
+      findPane(root, event.paneId)!.focusedTabId = event.tabId
+      return { root, activePaneId: event.paneId }
+    }
+
+    case 'focusNextPane': {
+      const current = state ?? initialLayout()
+      const leaves = paneLeaves(current.root)
+      if (leaves.length <= 1) return current
+      const idx = leaves.findIndex((l) => l.id === current.activePaneId)
+      const next = (idx + 1) % leaves.length
+      return { root: current.root, activePaneId: leaves[next]!.id }
+    }
+
+    case 'focusPrevPane': {
+      const current = state ?? initialLayout()
+      const leaves = paneLeaves(current.root)
+      if (leaves.length <= 1) return current
+      const idx = leaves.findIndex((l) => l.id === current.activePaneId)
+      const prev = (idx - 1 + leaves.length) % leaves.length
+      return { root: current.root, activePaneId: leaves[prev]!.id }
+    }
+
+    case 'focusNextTab': {
+      const current = state ?? initialLayout()
+      const pane = findPane(current.root, current.activePaneId)
+      if (!pane || pane.tabIds.length <= 1) return current
+      const idx = pane.tabIds.indexOf(pane.focusedTabId ?? '')
+      const next = idx < 0 ? 0 : (idx + 1) % pane.tabIds.length
+      const root = cloneNode(current.root)
+      findPane(root, pane.id)!.focusedTabId = pane.tabIds[next]!
+      return { root, activePaneId: pane.id }
+    }
+
+    case 'focusPrevTab': {
+      const current = state ?? initialLayout()
+      const pane = findPane(current.root, current.activePaneId)
+      if (!pane || pane.tabIds.length <= 1) return current
+      const idx = pane.tabIds.indexOf(pane.focusedTabId ?? '')
+      const prev = idx <= 0 ? pane.tabIds.length - 1 : idx - 1
+      const root = cloneNode(current.root)
+      findPane(root, pane.id)!.focusedTabId = pane.tabIds[prev]!
+      return { root, activePaneId: pane.id }
+    }
+
+    case 'removeTab': {
+      const current = state ?? initialLayout()
+      const leaves = paneLeaves(current.root)
+      let changed = false
+      const root = cloneNode(current.root)
+      for (const leaf of leaves) {
+        const rleaf = findPane(root, leaf.id)!
+        const idx = rleaf.tabIds.indexOf(event.tabId)
+        if (idx < 0) continue
+        changed = true
+        rleaf.tabIds.splice(idx, 1)
+        if (rleaf.focusedTabId === event.tabId) {
+          rleaf.focusedTabId = rleaf.tabIds[Math.min(idx, rleaf.tabIds.length - 1)] ?? null
+        }
+      }
+      if (!changed) return state
+      // Collapse any empty leaf panes (except if only one remains).
+      let next = root
+      let remaining = paneLeaves(next)
+      while (remaining.length > 1) {
+        const empty = remaining.find((l) => l.tabIds.length === 0)
+        if (!empty) break
+        const parent = findParent(next, empty.id)
+        if (!parent) break
+        parent.group.children.splice(parent.index, 1)
+        parent.group.sizes.splice(parent.index, 1)
+        parent.group.sizes = normalize(parent.group.sizes)
+        next = collapseGroups(next)
+        remaining = paneLeaves(next)
+      }
+      // If root collapsed to a single leaf, the workspace returns to the
+      // default single tab strip (non-persisted).
+      if (next.kind === 'leaf') return null
+      // If the active pane was removed, fall back to the first leaf with tabs.
+      const active = findPane(next, current.activePaneId)
+      const activeId =
+        active && active.tabIds.length > 0 ? active.id : paneLeaves(next).find((l) => l.tabIds.length > 0)?.id ?? paneLeaves(next)[0]!.id
+      return { root: next, activePaneId: activeId }
+    }
+
+    case 'closePane': {
+      const current = state ?? initialLayout()
+      const leaves = paneLeaves(current.root)
+      if (leaves.length <= 1) return null
+      const target = findPane(current.root, event.paneId)
+      if (!target) return state
+      const root = cloneNode(current.root)
+      const parent = findParent(root, event.paneId)
+      if (!parent) return null
+      const { group, index } = parent
+      group.children.splice(index, 1)
+      group.sizes.splice(index, 1)
+      group.sizes = normalize(group.sizes)
+      const cleaned = collapseGroups(root)
+      if (cleaned.kind === 'leaf') return null
+      const remaining = paneLeaves(cleaned)
+      const activeStillExists = remaining.some((l) => l.id === current.activePaneId && l.tabIds.length > 0)
+      const activeId = activeStillExists
+        ? current.activePaneId
+        : remaining.find((l) => l.tabIds.length > 0)?.id ?? remaining[0]!.id
+      return { root: cleaned, activePaneId: activeId }
+    }
+
+    case 'reorderTab': {
+      const current = state ?? initialLayout()
+      const pane = findPane(current.root, event.paneId)
+      if (!pane || !pane.tabIds.includes(event.tabId)) return current
+      const root = cloneNode(current.root)
+      const rleaf = findPane(root, event.paneId)!
+      const fromIdx = rleaf.tabIds.indexOf(event.tabId)
+      rleaf.tabIds.splice(fromIdx, 1)
+      const toIdx = Math.min(event.toIndex, rleaf.tabIds.length)
+      rleaf.tabIds.splice(toIdx, 0, event.tabId)
+      return { root, activePaneId: current.activePaneId }
+    }
+  }
+}

--- a/tabs/agent-tab-panel.tsx
+++ b/tabs/agent-tab-panel.tsx
@@ -1,0 +1,123 @@
+/**
+ * One agent tab's conversation panel (#46).
+ *
+ * Owns everything that must stay alive while its tab is in the background: the
+ * live timeline subscription (via `useAgentConversation`), its permission
+ * cards, and its own scroll state. The strip keeps every open agent tab's panel
+ * mounted and hides the unfocused ones with `display:none`, so switching tabs
+ * never tears down a subscription or resets scroll — background turns keep
+ * merging and the view jumps straight to where it was.
+ *
+ * The parent reads the active tab's conversation from `onConversation`, which
+ * this panel reports on every render (a ref map, never a state write, so there
+ * is no re-render loop).
+ */
+
+import React, { useRef } from 'react'
+import { useGpuix } from '@gpuix/react'
+import type { PaseoClient } from '@getpaseo/client'
+import type { DaemonClient } from '@getpaseo/client/internal/daemon-client'
+import { Transcript } from '../conversation/transcript'
+import { useAgentConversation } from '../conversation/conversation'
+import { useAgentPermissions } from '../conversation/permissions'
+import { useTranscriptFollow } from '../conversation/follow'
+import type { ImageAttachment } from '../composer/attachments'
+
+/** The live conversation surface one agent tab owns. */
+export type TabConversation = ReturnType<typeof useAgentConversation>
+
+export interface AgentTabPanelProps {
+  client: PaseoClient
+  daemon: DaemonClient
+  agentId: string
+  /** Seed for a draft-tab flip: the first optimistic user turn. */
+  seedText: string | null
+  seedImages: ImageAttachment[] | null
+  onSeedConsumed: () => void
+  /** True when this is the focused tab (visible); background tabs hide-not-unmount. */
+  hidden: boolean
+  /** False while a provider subagent view replaces the parent transcript. */
+  showTranscript: boolean
+  /** Reports this tab's conversation upward for composer/tracks/meter reads. */
+  onConversation: (agentId: string, conversation: TabConversation) => void
+  onEditQueued: (queuedId: string) => void
+  onOpenFile: (absolutePath: string) => void
+  workspaceRoot: string | null
+}
+
+export function AgentTabPanel({
+  client,
+  daemon,
+  agentId,
+  seedText,
+  seedImages,
+  onSeedConsumed,
+  hidden,
+  showTranscript,
+  onConversation,
+  onEditQueued,
+  onOpenFile,
+  workspaceRoot,
+}: AgentTabPanelProps) {
+  const conversation = useAgentConversation(client, agentId, {
+    seedText,
+    seedImages,
+    onSeedConsumed,
+  })
+  const permissions = useAgentPermissions(client, daemon, agentId)
+  const turns = conversation.turns
+
+  onConversation(agentId, conversation)
+
+  const listRef = useRef<{ id: number } | null>(null)
+
+  // Older-history availability for this tab's transcript top edge.
+  const olderPages =
+    conversation.status === 'ready' && turns.length > 0
+      ? conversation.loadingHistory
+        ? ('loading' as const)
+        : conversation.hasOlder
+          ? ('more' as const)
+          : ('end' as const)
+      : undefined
+
+  const { renderer } = useGpuix()
+  const { following, onScroll, requestJump, jumpToTurn } = useTranscriptFollow({
+    listRef,
+    turnCount: turns.length,
+    tailSignature: turns.length > 0 ? JSON.stringify(turns.at(-1)) : undefined,
+    agentId: agentId,
+    renderer,
+    slotOffset: olderPages ? 1 : 0,
+  })
+
+  return (
+    <div
+      style={{
+        display: hidden ? 'none' : 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        minHeight: 0,
+        width: '100%',
+      }}
+    >
+      {showTranscript && (
+        <Transcript
+          turns={turns}
+          permissions={permissions.cards}
+          onRespond={permissions.respond}
+          onEditQueued={onEditQueued}
+          workspaceRoot={workspaceRoot}
+          onOpenFile={onOpenFile}
+          listRef={listRef}
+          olderPages={olderPages}
+          onLoadOlder={conversation.loadHistory}
+          detached={!following}
+          onScroll={onScroll}
+          onJumpToBottom={requestJump}
+          onJumpToTurn={jumpToTurn}
+        />
+      )}
+    </div>
+  )
+}

--- a/tabs/pane-view.tsx
+++ b/tabs/pane-view.tsx
@@ -1,0 +1,242 @@
+/**
+ * Pane split-tree rendering for the workspace screen (#48).
+ *
+ * Renders a pane layout (a binary tree of horizontal/vertical groups over
+ * leaves holding ordered tabs) into nested flex regions, each leaf showing its
+ * own tab strip and focused tab's content. The tree geometry itself lives in
+ * the pure reducer (layout/layout.ts); this component only lays out nodes along
+ * their axis using the normalized sizes and hands each leaf's content to a
+ * render prop so the caller (chat.tsx) keeps the hide-not-unmount
+ * AgentTabPanels and decides draft/empty-pane content.
+ *
+ * When the layout is null the workspace falls back to a single implicit pane:
+ * all of the #46 workspace's tabs, focusing the #46 active draft/agent (handled
+ * by the caller, which renders a plain TabStrip + panel in that case).
+ */
+
+import React from 'react'
+import { C } from '../chrome/theme'
+import { TabStrip } from './tab-strip'
+import type { PaneGroup, PaneLayout, PaneNode } from '../layout/layout'
+import type { TabDescriptor } from './tabs'
+
+/** The splitter bar's thickness along the split axis. */
+export const SPLITTER = 5
+
+/** The per-tab strip decoration the caller supplies (labels, dots, attention). */
+export interface PaneStripMeta {
+  labelFor: (tab: TabDescriptor) => string
+  dotColorFor?: (tab: TabDescriptor) => string | null
+  attentionFor?: (tab: TabDescriptor) => boolean
+}
+
+interface PaneSplitProps {
+  layout: PaneLayout
+  tabs: TabDescriptor[]
+  meta: PaneStripMeta
+  /**
+   * Renders one pane's content below its tab strip: the focused tab's panel
+   * (an AgentTabPanel), a draft center message, or an empty-pane hint.
+   */
+  renderPane: (paneId: string, tabIds: string[], focusedTabId: string | null) => React.ReactNode
+  onSelectTab: (paneId: string, tabId: string) => void
+  onCloseTab: (paneId: string, tabId: string) => void
+  onCloseOthers: (paneId: string, tabId: string) => void
+  onNewDraft: (paneId: string) => void
+}
+
+/** Bar between panes along a split axis. */
+function SplitDivider({ direction }: { direction: 'horizontal' | 'vertical' }) {
+  return (
+    <div
+      style={{
+        flexShrink: 0,
+        ...(direction === 'horizontal'
+          ? { width: SPLITTER, height: '100%' }
+          : { width: '100%', height: SPLITTER }),
+        backgroundColor: C.border,
+      }}
+    />
+  )
+}
+
+/** A leaf pane: its tab strip (ordered subset) plus focused tab's content. */
+function PaneLeafBody({
+  pane,
+  tabs,
+  meta,
+  renderPane,
+  onSelectTab,
+  onCloseTab,
+  onCloseOthers,
+  onNewDraft,
+}: {
+  pane: { id: string; tabIds: string[]; focusedTabId: string | null }
+  tabs: TabDescriptor[]
+  meta: PaneStripMeta
+  renderPane: PaneSplitProps['renderPane']
+  onSelectTab: PaneSplitProps['onSelectTab']
+  onCloseTab: PaneSplitProps['onCloseTab']
+  onCloseOthers: PaneSplitProps['onCloseOthers']
+  onNewDraft: PaneSplitProps['onNewDraft']
+}) {
+  const paneTabs = pane.tabIds
+    .map((id) => tabs.find((tab) => tab.id === id))
+    .filter((tab): tab is TabDescriptor => Boolean(tab))
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1, minWidth: 0, minHeight: 0 }}>
+      <TabStrip
+        tabs={paneTabs}
+        activeTabId={pane.focusedTabId}
+        labelFor={meta.labelFor}
+        dotColorFor={meta.dotColorFor}
+        attentionFor={meta.attentionFor}
+        onSelect={(tabId) => onSelectTab(pane.id, tabId)}
+        onClose={(tabId) => onCloseTab(pane.id, tabId)}
+        onCloseOthers={(tabId) => onCloseOthers(pane.id, tabId)}
+        onNewDraft={() => onNewDraft(pane.id)}
+      />
+      {renderPane(pane.id, pane.tabIds, pane.focusedTabId)}
+    </div>
+  )
+}
+
+/** Recursively lays out a group's children along its axis with the split bars. */
+function PaneGroupBody({
+  node,
+  tabs,
+  meta,
+  renderPane,
+  onSelectTab,
+  onCloseTab,
+  onCloseOthers,
+  onNewDraft,
+}: {
+  node: PaneGroup
+  tabs: TabDescriptor[]
+  meta: PaneStripMeta
+  renderPane: PaneSplitProps['renderPane']
+  onSelectTab: PaneSplitProps['onSelectTab']
+  onCloseTab: PaneSplitProps['onCloseTab']
+  onCloseOthers: PaneSplitProps['onCloseOthers']
+  onNewDraft: PaneSplitProps['onNewDraft']
+}) {
+  const row = node.direction === 'horizontal'
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flex: 1,
+        minWidth: 0,
+        minHeight: 0,
+        ...(row ? { flexDirection: 'row' } : { flexDirection: 'column' }),
+      }}
+    >
+      <PaneSubtree
+        node={node.children[0]!}
+        size={node.sizes[0] ?? 0.5}
+        tabs={tabs}
+        meta={meta}
+        renderPane={renderPane}
+        onSelectTab={onSelectTab}
+        onCloseTab={onCloseTab}
+        onCloseOthers={onCloseOthers}
+        onNewDraft={onNewDraft}
+      />
+      <SplitDivider direction={node.direction} />
+      <PaneSubtree
+        node={node.children[1]!}
+        size={node.sizes[1] ?? 0.5}
+        tabs={tabs}
+        meta={meta}
+        renderPane={renderPane}
+        onSelectTab={onSelectTab}
+        onCloseTab={onCloseTab}
+        onCloseOthers={onCloseOthers}
+        onNewDraft={onNewDraft}
+      />
+    </div>
+  )
+}
+
+/** One subtree rendered at a flex fraction of its parent. */
+function PaneSubtree({
+  node,
+  size,
+  tabs,
+  meta,
+  renderPane,
+  onSelectTab,
+  onCloseTab,
+  onCloseOthers,
+  onNewDraft,
+}: {
+  node: PaneNode
+  size: number
+  tabs: TabDescriptor[]
+  meta: PaneStripMeta
+  renderPane: PaneSplitProps['renderPane']
+  onSelectTab: PaneSplitProps['onSelectTab']
+  onCloseTab: PaneSplitProps['onCloseTab']
+  onCloseOthers: PaneSplitProps['onCloseOthers']
+  onNewDraft: PaneSplitProps['onNewDraft']
+}) {
+  const style = {
+    display: 'flex',
+    flexGrow: size,
+    flexBasis: 0,
+    minWidth: 0,
+    minHeight: 0,
+    overflow: 'hidden',
+  } as React.CSSProperties
+  if (node.kind === 'leaf') {
+    return (
+      <div style={style}>
+        <PaneLeafBody
+          pane={{ id: node.id, tabIds: node.tabIds, focusedTabId: node.focusedTabId }}
+          tabs={tabs}
+          meta={meta}
+          renderPane={renderPane}
+          onSelectTab={onSelectTab}
+          onCloseTab={onCloseTab}
+          onCloseOthers={onCloseOthers}
+          onNewDraft={onNewDraft}
+        />
+      </div>
+    )
+  }
+  return (
+    <div style={style}>
+      <PaneGroupBody
+        node={node}
+        tabs={tabs}
+        meta={meta}
+        renderPane={renderPane}
+        onSelectTab={onSelectTab}
+        onCloseTab={onCloseTab}
+        onCloseOthers={onCloseOthers}
+        onNewDraft={onNewDraft}
+      />
+    </div>
+  )
+}
+
+/** Renders a persisted multi-pane layout; see module docstring for the null contract. */
+export function PaneSplit(props: PaneSplitProps) {
+  const { layout, tabs, meta, renderPane, onSelectTab, onCloseTab, onCloseOthers, onNewDraft } = props
+  return (
+    <div style={{ display: 'flex', flex: 1, minWidth: 0, minHeight: 0, flexDirection: 'row' }}>
+      <PaneSubtree
+        node={layout.root}
+        size={1}
+        tabs={tabs}
+        meta={meta}
+        renderPane={renderPane}
+        onSelectTab={onSelectTab}
+        onCloseTab={onCloseTab}
+        onCloseOthers={onCloseOthers}
+        onNewDraft={onNewDraft}
+      />
+    </div>
+  )
+}

--- a/tabs/setup-tab-panel.tsx
+++ b/tabs/setup-tab-panel.tsx
@@ -1,0 +1,159 @@
+/**
+ * One setup tab's content (#47): a live worktree bootstrap log.
+ *
+ * Renders the snapshot the setup store holds for its workspace — per-command
+ * ✓/✗/• meta lines plus logs, via the same `toolDetailParts` mapping the
+ * worktree_setup tool turn uses. While running it streams as pushes land; on
+ * success it collapses to a summary chip (the tab keeps the log reachable,
+ * expandable in place); on failure the error and failing output stay visible
+ * inline so the worktree never becomes a black box.
+ *
+ * On mount it asks the daemon for the snapshot in case the store skipped ahead
+ * (reattach/initial state); the store's freshness guard retires a stale reply.
+ */
+
+import React, { useEffect, useState } from 'react'
+import { C } from '../chrome/theme'
+import { Icon } from '../chrome/chrome'
+import { toolDetailParts, type ToolCallDetail } from '../daemon/paseo'
+import { setupSucceeded, type SetupSnapshot } from './setup'
+
+export interface SetupTabPanelProps {
+  workspaceId: string
+  snapshot: SetupSnapshot | null
+  /** Seeds the reattach snapshot for this workspace on mount. */
+  refresh: (workspaceId: string) => void
+  /** True when this is the focused tab (visible); background tabs hide-not-unmount. */
+  hidden: boolean
+}
+
+/** The one-line summary chip shown once setup succeeds, holding the count. */
+function setupSummary(snapshot: SetupSnapshot): string {
+  const count = snapshot.detail.commands.length
+  return `${count} ${count === 1 ? 'command' : 'commands'}`
+}
+
+export function SetupTabPanel({ workspaceId, snapshot, refresh, hidden }: SetupTabPanelProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  useEffect(() => {
+    refresh(workspaceId)
+  }, [refresh, workspaceId])
+
+  // A completed setup collapses to a summary chip but stays reachable; a
+  // running or failed one always shows its live detail. Switching workspaces
+  // collapses again so a fresh tab opens to its summary.
+  useEffect(() => {
+    setExpanded(false)
+  }, [workspaceId])
+
+  const done = setupSucceeded(snapshot)
+  const failed = snapshot?.status === 'failed'
+  const showDetail = expanded || !done
+
+  const parts =
+    snapshot && showDetail
+      ? toolDetailParts(snapshot.detail as unknown as ToolCallDetail)
+      : []
+
+  const headerText = failed
+    ? 'Setup failed'
+    : done
+      ? 'Setup complete'
+      : 'Setting up worktree…'
+  const headerColor = failed ? C.danger : done ? C.success : C.running
+
+  return (
+    <div
+      style={{
+        display: hidden ? 'none' : 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        minHeight: 0,
+        width: '100%',
+        overflowY: 'auto',
+      }}
+    >
+      <div
+        testId="setup-tab"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          padding: 16,
+          maxWidth: 720,
+          alignSelf: 'center',
+          width: '100%',
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+            <text style={{ fontSize: 15, fontWeight: 600, color: C.text }}>{headerText}</text>
+            {!snapshot && !failed && (
+              <text style={{ fontSize: 12, color: C.running }}>Waiting for the daemon…</text>
+            )}
+          </div>
+          {snapshot && (
+            <text style={{ fontSize: 12, color: C.secondary }}>
+              {snapshot.detail.branchName} · {snapshot.detail.worktreePath}
+            </text>
+          )}
+          {failed && snapshot?.error && (
+            <text style={{ fontSize: 12, color: C.danger }}>{snapshot.error}</text>
+          )}
+        </div>
+
+        {done && !showDetail && (
+          <div
+            testId="setup-summary-chip"
+            onClick={() => setExpanded(true)}
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 8,
+              padding: '6px 10px',
+              borderRadius: 6,
+              backgroundColor: C.raised,
+              border: `1px solid ${C.border}`,
+              cursor: 'default',
+            }}
+          >
+            <Icon name="check" size={13} color={headerColor} />
+            <text style={{ fontSize: 13, color: C.text }}>{setupSummary(snapshot)}</text>
+            <text style={{ fontSize: 12, color: C.secondary, flexGrow: 1 }}>— setup complete</text>
+            <Icon name="chevronDown" size={12} color={C.secondary} />
+          </div>
+        )}
+
+        {parts.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {parts.map((part, i) =>
+              part.type === 'meta' ? (
+                <text
+                  key={i}
+                  style={{ fontSize: 13, color: part.tone === 'ok' ? C.ok : part.tone === 'danger' ? C.danger : C.tertiary }}
+                >
+                  {part.text}
+                </text>
+              ) : (
+                <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0 }}>
+                  {part.label && (
+                    <text style={{ fontSize: 10.5, fontWeight: 500, color: C.ghost, flexShrink: 0 }}>
+                      {part.label.toUpperCase()}
+                    </text>
+                  )}
+                  <text
+                    style={{ fontSize: 12, lineHeight: 17, fontFamily: 'monospace', color: C.secondary, minWidth: 0, maxWidth: '100%' }}
+                  >
+                    {part.text}
+                  </text>
+                </div>
+              ),
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/tabs/setup.test.ts
+++ b/tabs/setup.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  initialSetupState,
+  reduceSetup,
+  selectSetup,
+  setupSucceeded,
+  type SetupCommandStep,
+  type SetupEvent,
+  type SetupState,
+  type WorktreeSetupDetail,
+} from './setup'
+
+function command(over: Partial<SetupCommandStep> = {}): SetupCommandStep {
+  return {
+    index: 0,
+    command: 'git checkout',
+    cwd: '/ws',
+    log: '',
+    status: 'running',
+    exitCode: null,
+    ...over,
+  }
+}
+
+function detail(over: Partial<WorktreeSetupDetail> = {}): WorktreeSetupDetail {
+  return {
+    type: 'worktree_setup',
+    worktreePath: '/ws/worktree',
+    branchName: 'feature',
+    log: '',
+    commands: [],
+    ...over,
+  }
+}
+
+function run(events: SetupEvent[]): SetupState {
+  return events.reduce(reduceSetup, initialSetupState)
+}
+
+const arrived = (workspaceId: string, over: Partial<SetupEvent & { status: 'running' }> = {}) =>
+  ({
+    type: 'progressArrived',
+    workspaceId,
+    status: 'running',
+    detail: detail(),
+    error: null,
+    ...over,
+  }) as SetupEvent
+
+describe('workspace setup store', () => {
+  test('initial state holds no snapshots', () => {
+    expect(initialSetupState.entries).toEqual({})
+    expect(selectSetup(initialSetupState, 'ws1')).toBe(null)
+    expect(setupSucceeded(selectSetup(initialSetupState, 'ws1'))).toBe(false)
+  })
+
+  test('reset drops every snapshot back to empty', () => {
+    const state = run([arrived('ws1'), { type: 'reset' }])
+    expect(state.entries).toEqual({})
+  })
+
+  test('a progress push folds into a per-workspace snapshot', () => {
+    const state = run([
+      {
+        type: 'progressArrived',
+        workspaceId: 'ws1',
+        status: 'running',
+        detail: detail({ commands: [command({ command: 'npm install', status: 'completed', exitCode: 0 })] }),
+        error: null,
+      },
+    ])
+    expect(selectSetup(state, 'ws1')).toEqual({
+      status: 'running',
+      detail: {
+        type: 'worktree_setup',
+        worktreePath: '/ws/worktree',
+        branchName: 'feature',
+        log: '',
+        commands: [{ index: 0, command: 'npm install', cwd: '/ws', log: '', status: 'completed', exitCode: 0 }],
+        truncated: undefined,
+      },
+      error: null,
+    })
+    // Other workspaces stay untouched.
+    expect(selectSetup(state, 'ws2')).toBe(null)
+  })
+
+  test('a newer report replaces the prior one for its workspace, never stacking', () => {
+    const state = run([
+      arrived('ws1', { status: 'running' }),
+      {
+        type: 'progressArrived',
+        workspaceId: 'ws1',
+        status: 'completed',
+        detail: detail({ commands: [command()] }),
+        error: null,
+      },
+    ])
+    expect(Object.keys(state.entries)).toEqual(['ws1'])
+    expect(selectSetup(state, 'ws1')?.status).toBe('completed')
+    expect(setupSucceeded(selectSetup(state, 'ws1'))).toBe(true)
+  })
+
+  test('workspaces fold independently of one another', () => {
+    const state = run([
+      { ...arrived('ws1'), status: 'running' },
+      { ...arrived('ws2'), status: 'running' },
+    ])
+    expect(selectSetup(state, 'ws1')).not.toBe(null)
+    expect(selectSetup(state, 'ws2')).not.toBe(null)
+    expect(Object.keys(state.entries)).toEqual(['ws1', 'ws2'])
+  })
+
+  test('a failure keeps the error and failing status visible', () => {
+    const state = run([
+      {
+        type: 'progressArrived',
+        workspaceId: 'ws1',
+        status: 'failed',
+        detail: detail({
+          commands: [command({ command: 'git checkout', status: 'failed', exitCode: 128, log: 'fatal' })],
+        }),
+        error: 'checkout failed',
+      },
+    ])
+    const snapshot = selectSetup(state, 'ws1')
+    expect(snapshot?.status).toBe('failed')
+    expect(snapshot?.error).toBe('checkout failed')
+    expect(snapshot?.detail.commands[0]?.exitCode).toBe(128)
+    expect(setupSucceeded(snapshot)).toBe(false)
+  })
+
+  test('progress for a workspace is inert until reported', () => {
+    expect(setupSucceeded(selectSetup(initialSetupState, 'missing'))).toBe(false)
+    expect(setupSucceeded(null)).toBe(false)
+  })
+})

--- a/tabs/setup.ts
+++ b/tabs/setup.ts
@@ -1,0 +1,156 @@
+/**
+ * Workspace setup progress: the bootstrap commands a fresh worktree runs
+ * (checkout, install, env) while its first agent starts.
+ *
+ * One store per app, keyed by workspaceId, fed exclusively by daemon truth:
+ * `workspace_setup_progress` pushes plus a `fetchWorkspaceSetupStatus` snapshot
+ * for reattach/initial state. The reducer is the whole store — the hook only
+ * translates daemon events and drives the reattach fetch, mirroring checkout.
+ * Non-worktree agents never emit progress, so they never write here.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { DaemonClient } from '@getpaseo/client/internal/daemon-client'
+import { createStatusFreshness } from '../checkout/checkout'
+
+export type SetupStatus = 'running' | 'completed' | 'failed'
+
+export interface SetupCommandStep {
+  index: number
+  command: string
+  cwd: string
+  log: string
+  status: SetupStatus
+  exitCode: number | null
+}
+
+/** The structured worktree-setup detail, identical on pushes and snapshots. */
+export interface WorktreeSetupDetail {
+  type: 'worktree_setup'
+  worktreePath: string
+  branchName: string
+  log: string
+  commands: SetupCommandStep[]
+  truncated?: boolean
+}
+
+/** One workspace's folded setup progress, as the daemon last reported it. */
+export interface SetupSnapshot {
+  status: SetupStatus
+  detail: WorktreeSetupDetail
+  error: string | null
+}
+
+/** Per-workspace setup progress; absent means the daemon has reported none. */
+export interface SetupState {
+  entries: Record<string, SetupSnapshot>
+}
+
+export const initialSetupState: SetupState = { entries: {} }
+
+export type SetupEvent =
+  | { type: 'reset' }
+  | {
+      type: 'progressArrived'
+      workspaceId: string
+      status: SetupStatus
+      detail: WorktreeSetupDetail
+      error: string | null
+    }
+
+export function reduceSetup(state: SetupState, event: SetupEvent): SetupState {
+  switch (event.type) {
+    case 'reset':
+      return initialSetupState
+    case 'progressArrived':
+      // A push or snapshot carries the full fold for its workspace; the newest
+      // report simply replaces the prior one, never stacking.
+      return {
+        entries: {
+          ...state.entries,
+          [event.workspaceId]: { status: event.status, detail: event.detail, error: event.error },
+        },
+      }
+  }
+}
+
+export function selectSetup(state: SetupState, workspaceId: string): SetupSnapshot | null {
+  return state.entries[workspaceId] ?? null
+}
+
+/** True once the workspace's setup reported success; drives the tab's hand-off. */
+export function setupSucceeded(snapshot: SetupSnapshot | null): boolean {
+  return snapshot?.status === 'completed'
+}
+
+// ---- live hook ---------------------------------------------------------------
+
+/** Local structural copy of the push/snapshot payload, decoupled from protocol. */
+interface SetupPushPayload {
+  workspaceId: string
+  status: SetupStatus
+  detail: WorktreeSetupDetail
+  error: string | null
+}
+
+/**
+ * Subscribes once to every workspace's setup progress and streams it into the
+ * store; `refresh` seeds a workspace's reattach snapshot. A fetch response is
+ * judged by the same freshness guard as checkout, so it can never overwrite a
+ * newer push that landed while the request was in flight.
+ */
+export function useWorkspaceSetup(daemon: DaemonClient): {
+  state: SetupState
+  refresh: (workspaceId: string) => void
+} {
+  const [state, setState] = useState<SetupState>(initialSetupState)
+  const disposedRef = useRef(false)
+  const freshness = useRef(createStatusFreshness())
+
+  const refresh = useCallback(
+    (workspaceId: string) => {
+      const token = freshness.current.issue(workspaceId)
+      void daemon
+        .fetchWorkspaceSetupStatus(workspaceId)
+        .then((payload) => {
+          const snapshot = payload.snapshot
+          if (!snapshot || disposedRef.current || !freshness.current.canApply(workspaceId, token)) return
+          const folded = snapshot as unknown as Omit<SetupPushPayload, 'workspaceId'>
+          setState((prev) =>
+            reduceSetup(prev, {
+              type: 'progressArrived',
+              workspaceId,
+              status: folded.status,
+              detail: folded.detail,
+              error: folded.error,
+            }),
+          )
+        })
+        .catch(() => {})
+    },
+    [daemon],
+  )
+
+  useEffect(() => {
+    disposedRef.current = false
+    const unsub = daemon.on('workspace_setup_progress', (message) => {
+      freshness.current.recordPush(message.workspaceId)
+      const payload = message.payload as unknown as SetupPushPayload
+      setState((prev) =>
+        reduceSetup(prev, {
+          type: 'progressArrived',
+          workspaceId: payload.workspaceId,
+          status: payload.status,
+          detail: payload.detail,
+          error: payload.error,
+        }),
+      )
+    })
+    return () => {
+      disposedRef.current = true
+      unsub()
+    }
+  }, [daemon])
+
+  return { state, refresh }
+}

--- a/tabs/tab-strip.tsx
+++ b/tabs/tab-strip.tsx
@@ -1,0 +1,235 @@
+/**
+ * The workspace tab strip (#46).
+ *
+ * One row above a tab's screen holding every open tab: agent tabs (a
+ * running/finished conversation), draft tabs (a candidate prompt not yet sent),
+ * and a trailing "new draft" affordance. The reducer owns order and focus —
+ * this component only renders and translates pointer gestures into TabsEvents.
+ *
+ * Enrollment keeps focus on the focused tab across a close-others: the strip
+ * renders the survivors' Close-others item disabled for the surviving tab.
+ */
+
+import React, { useState } from 'react'
+import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger } from '@gpuix/react'
+import { C, TRAFFIC_LIGHT_CLEARANCE } from '../chrome/theme'
+import { Icon } from '../chrome/chrome'
+import type { TabDescriptor } from './tabs'
+
+export const TAB_STRIP_HEIGHT = 34
+
+interface TabStripProps {
+  tabs: TabDescriptor[]
+  activeTabId: string | null
+  /** Per-tab display label (agent display name, or a draft's directory basename). */
+  labelFor: (tab: TabDescriptor) => string
+  /** Optional per-tab accent dot color (e.g. agent status); null shows none. */
+  dotColorFor?: (tab: TabDescriptor) => string | null
+  /** True when a tab should surface the user's attention (e.g. permission). */
+  attentionFor?: (tab: TabDescriptor) => boolean
+  onSelect: (tabId: string) => void
+  onClose: (tabId: string) => void
+  onCloseOthers: (tabId: string) => void
+  onNewDraft: () => void
+}
+
+/** One tab: label, optional accent dot, hover/tail close affordance, active state. */
+function StripTab({
+  tab,
+  active,
+  label,
+  dotColor,
+  attention,
+  onSelect,
+  onClose,
+}: {
+  tab: TabDescriptor
+  active: boolean
+  label: string
+  dotColor: string | null
+  attention: boolean
+  onSelect: () => void
+  onClose: () => void
+}) {
+  const [hover, setHover] = useState(false)
+  const show = hover || active
+  return (
+    <div
+      testId="tab"
+      role="tab"
+      aria-selected={active}
+      onClick={onSelect}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        height: '100%',
+        paddingLeft: 12,
+        paddingRight: 8,
+        maxWidth: 200,
+        cursor: 'default',
+        userSelect: 'none',
+        backgroundColor: active ? C.raised : 'transparent',
+        boxShadow: active ? `inset 0 1px 0 ${C.borderStrong}` : undefined,
+        color: active ? C.text : C.secondary,
+        borderRight: `1px solid ${C.border}`,
+      }}
+    >
+      {dotColor && (
+        <div
+          style={{
+            width: 6,
+            height: 6,
+            flexShrink: 0,
+            borderRadius: 3,
+            backgroundColor: dotColor,
+            ...(attention ? { boxShadow: `0 0 6px ${dotColor}` } : {}),
+          }}
+        />
+      )}
+      <text
+        style={{
+          flexShrink: 0,
+          fontSize: 12,
+          fontWeight: active ? 600 : 500,
+          lineHeight: 16,
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {label}
+      </text>
+      <div
+        testId={`tab-close-${tab.id}`}
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation()
+          onClose()
+        }}
+        style={{
+          display: show ? 'flex' : 'none',
+          width: 16,
+          height: 16,
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          borderRadius: 4,
+          backgroundColor: hover ? C.overlay : 'transparent',
+        }}
+      >
+        <Icon name="x" size={11} color={C.secondary} />
+      </div>
+    </div>
+  )
+}
+
+export function TabStrip({
+  tabs,
+  activeTabId,
+  labelFor,
+  dotColorFor,
+  attentionFor,
+  onSelect,
+  onClose,
+  onCloseOthers,
+  onNewDraft,
+}: TabStripProps) {
+  const active = tabs.find((tab) => tab.id === activeTabId) ?? null
+
+  return (
+    <div
+      testId="tab-strip"
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'stretch',
+        height: TAB_STRIP_HEIGHT,
+        flexShrink: 0,
+        overflowX: 'auto',
+        overflowY: 'hidden',
+        backgroundColor: C.composer,
+        borderBottom: `1px solid ${C.border}`,
+        paddingLeft: TRAFFIC_LIGHT_CLEARANCE + 2,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'stretch',
+          flexGrow: 1,
+          minWidth: 0,
+        }}
+      >
+        {tabs.map((tab) => (
+          <StripTab
+            key={tab.id}
+            tab={tab}
+            active={tab.id === activeTabId}
+            label={labelFor(tab)}
+            dotColor={dotColorFor?.(tab) ?? null}
+            attention={attentionFor?.(tab) ?? false}
+            onSelect={() => onSelect(tab.id)}
+            onClose={() => onClose(tab.id)}
+          />
+        ))}
+      </div>
+      <div
+        testId="tab-new-draft"
+        onClick={onNewDraft}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 34,
+          height: '100%',
+          flexShrink: 0,
+          color: C.secondary,
+          borderRight: `1px solid ${C.border}`,
+        }}
+      >
+        <Icon name="compose" size={14} color={C.secondary} />
+      </div>
+      <Select
+        value=""
+        onValueChange={(value) => {
+          if (value === 'close-others' && active) onCloseOthers(active.id)
+          else if (value === 'new-draft') onNewDraft()
+        }}
+      >
+        <SelectTrigger
+          testId="tab-menu"
+          style={(state) => ({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 34,
+            height: '100%',
+            flexShrink: 0,
+            backgroundColor: state.open ? C.overlay : 'transparent',
+            border: 'none',
+            cursor: 'default',
+          })}
+        >
+          <Icon name="ellipsis" size={14} color={C.secondary} />
+        </SelectTrigger>
+        <SelectContent side="bottom" align="end" sideOffset={2} style={{ width: 200 }}>
+          <SelectItem value="close-others" textValue="Close other tabs" disabled={!active || tabs.length <= 1}>
+            <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <text style={{ fontSize: 13, color: C.text }}>Close other tabs</text>
+            </div>
+          </SelectItem>
+          <SelectSeparator />
+          <SelectItem value="new-draft" textValue="New draft">
+            <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <text style={{ fontSize: 13, color: C.text }}>New draft</text>
+            </div>
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/tabs/tabs.test.ts
+++ b/tabs/tabs.test.ts
@@ -247,6 +247,48 @@ describe('workspace tabs', () => {
     expect(state.tabs.map((tab) => tab.target)).toEqual(['agent', 'draft', 'draft', 'agent'])
   })
 
+  test('openSetup appends a setup tab keyed by workspace and focuses it', () => {
+    const state = run([{ type: 'openSetup', workspaceId: 'ws1', agentId: 'a1', createdAt: 10 }])
+    expect(state.tabs).toHaveLength(1)
+    expect(state.tabs[0]!.target).toBe('setup')
+    expect(state.tabs[0]!.state).toEqual({ workspaceId: 'ws1', agentId: 'a1' })
+    expect(state.activeTabId).toBe(state.tabs[0]!.id)
+  })
+
+  test('openSetup reuses an existing setup tab for the same workspace', () => {
+    const state = run([
+      { type: 'openSetup', workspaceId: 'ws1', agentId: 'a1', createdAt: 10 },
+      { type: 'openSetup', workspaceId: 'ws1', agentId: 'a2', createdAt: 20 },
+    ])
+    expect(state.tabs).toHaveLength(1)
+    expect(state.tabs[0]!.state.agentId).toBe('a1')
+    expect(state.activeTabId).toBe(state.tabs[0]!.id)
+  })
+
+  test('openSetup opens distinct tabs for distinct workspaces', () => {
+    const state = run([
+      { type: 'openSetup', workspaceId: 'ws1', agentId: 'a1', createdAt: 10 },
+      { type: 'openSetup', workspaceId: 'ws2', agentId: 'a2', createdAt: 20 },
+    ])
+    expect(state.tabs).toHaveLength(2)
+    expect(state.tabs.map((tab) => (tab.target === 'setup' && tab.state.workspaceId) || null)).toEqual([
+      'ws1',
+      'ws2',
+    ])
+    expect(state.activeTabId).toBe(state.tabs[1]!.id)
+  })
+
+  test('closing a setup tab follows the neighbor rule and setup tabs select cleanly', () => {
+    const state = run([
+      { type: 'openWorkspace', agents: [at('a1', 10)], cwd: '/ws', now: 20 },
+      { type: 'openSetup', workspaceId: 'ws1', agentId: 'a1', createdAt: 30 },
+    ])
+    expect(state.tabs.map((tab) => tab.target)).toEqual(['agent', 'draft', 'setup'])
+    const afterClose = reduceTabs(state, { type: 'close', tabId: state.tabs[2]!.id })
+    expect(afterClose.tabs.map((tab) => tab.target)).toEqual(['agent', 'draft'])
+    expect(afterClose.activeTabId).toBe(afterClose.tabs[1]!.id)
+  })
+
   test('selectTabs and selectTab project the ordered list and single lookups', () => {
     const state = run([{ type: 'openWorkspace', agents: [at('a1', 10)], cwd: '/ws', now: 20 }])
     expect(selectTabs(state)).toHaveLength(2)

--- a/tabs/tabs.test.ts
+++ b/tabs/tabs.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  hasAgentTab,
+  initialTabs,
+  reduceTabs,
+  selectActiveAgentId,
+  selectActiveTab,
+  selectTab,
+  selectTabs,
+  type TabsEvent,
+  type TabsState,
+} from './tabs'
+
+function run(events: TabsEvent[]): TabsState {
+  return events.reduce(reduceTabs, initialTabs)
+}
+
+const at = (id: string, createdAt: number) => ({ id, createdAt })
+
+describe('workspace tabs', () => {
+  test('initial state has no tabs and no active tab', () => {
+    expect(initialTabs.tabs).toEqual([])
+    expect(initialTabs.activeTabId).toBe(null)
+    expect(selectActiveTab(initialTabs)).toBe(null)
+    expect(selectActiveAgentId(initialTabs)).toBe(null)
+  })
+
+  test('reset drops every tab back to the directory new-task state', () => {
+    const state = run([
+      { type: 'openWorkspace', agents: [], cwd: '/ws', now: 100 },
+      { type: 'reset' },
+    ])
+    expect(state.tabs).toEqual([])
+    expect(state.activeTabId).toBe(null)
+  })
+
+  test('opening a workspace with no agents yields one focused draft tab', () => {
+    const state = run([{ type: 'openWorkspace', agents: [], cwd: '/ws', now: 5 }])
+    expect(state.tabs).toHaveLength(1)
+    expect(state.tabs[0]!.target).toBe('draft')
+    expect(state.tabs[0]!.state).toEqual({ cwd: '/ws', worktree: 'local' })
+    expect(state.activeTabId).toBe(state.tabs[0]!.id)
+  })
+
+  test('opening a workspace with N agents shows N agent tabs plus a draft tab', () => {
+    const state = run([
+      {
+        type: 'openWorkspace',
+        agents: [at('a2', 200), at('a1', 100), at('a3', 300)],
+        cwd: '/ws',
+        now: 400,
+      },
+    ])
+    // Newest agent first, then the trailing draft.
+    expect(state.tabs.map((tab) => tab.target)).toEqual(['agent', 'agent', 'agent', 'draft'])
+    expect(state.tabs.map((tab) => tab.target === 'agent' && tab.state.agentId)).toEqual([
+      'a3',
+      'a2',
+      'a1',
+      false,
+    ])
+    // Opens onto the most recent agent.
+    expect(selectActiveAgentId(state)).toBe('a3')
+    expect(state.activeTabId).toBe(state.tabs[0]!.id)
+  })
+
+  test('re-opening a workspace reuses existing agent tabs without duplicating', () => {
+    const open = { type: 'openWorkspace', agents: [at('a1', 100)], cwd: '/ws', now: 200 } as TabsEvent
+    const once = run([open])
+    const twice = run([open, open])
+    expect(twice.tabs.filter((tab) => tab.target === 'agent')).toHaveLength(1)
+    // The draft tab is not duplicated either.
+    expect(twice.tabs.filter((tab) => tab.target === 'draft')).toHaveLength(1)
+    expect(twice.activeTabId).toBe(selectTab(once, once.tabs[0]!.id)!.id)
+  })
+
+  test('openDraft appends a draft tab and focuses it', () => {
+    const state = run([
+      { type: 'openDraft', cwd: '/ws', now: 10 },
+      { type: 'openDraft', cwd: '/ws', now: 20 },
+    ])
+    expect(state.tabs).toHaveLength(2)
+    expect(state.tabs.every((tab) => tab.target === 'draft')).toBe(true)
+    expect(state.activeTabId).toBe(state.tabs[1]!.id)
+    // Unique ids.
+    expect(new Set(state.tabs.map((tab) => tab.id)).size).toBe(2)
+  })
+
+  test('openAgent focuses an existing agent tab instead of duplicating it', () => {
+    const state = run([
+      { type: 'openWorkspace', agents: [at('a1', 100), at('a2', 200)], cwd: '/ws', now: 300 },
+      { type: 'openAgent', agentId: 'a1', createdAt: 100 },
+    ])
+    expect(state.tabs.filter((tab) => tab.target === 'agent')).toHaveLength(2)
+    expect(selectActiveAgentId(state)).toBe('a1')
+  })
+
+  test('openAgent creates a brand-new agent tab when none exists for it', () => {
+    const state = run([{ type: 'openAgent', agentId: 'x', createdAt: 5 }])
+    expect(state.tabs).toHaveLength(1)
+    expect(state.tabs[0]!.target).toBe('agent')
+    expect(state.tabs[0]!.state).toEqual({ agentId: 'x' })
+    expect(selectActiveAgentId(state)).toBe('x')
+  })
+
+  test('draftSent flips the draft tab into an agent tab in place and focuses it', () => {
+    const state = run([
+      { type: 'openDraft', cwd: '/ws', now: 10 },
+      { type: 'draftSent', tabId: 't0', agentId: 'new-agent', createdAt: 11 },
+    ])
+    expect(state.tabs).toHaveLength(1)
+    expect(state.tabs[0]!.target).toBe('agent')
+    expect(state.tabs[0]!.state).toEqual({ agentId: 'new-agent' })
+    // The id survives the flip, so the strip does not jump.
+    expect(state.tabs[0]!.id).toBe('t0')
+    expect(state.activeTabId).toBe('t0')
+    expect(selectActiveAgentId(state)).toBe('new-agent')
+  })
+
+  test('draftSent is ignored for a non-draft tab or an unknown tab', () => {
+    const state = run([
+      { type: 'openAgent', agentId: 'a1', createdAt: 1 },
+      { type: 'draftSent', tabId: 't0', agentId: 'x', createdAt: 2 },
+    ])
+    expect(state.tabs[0]!.target).toBe('agent')
+    expect(state.tabs[0]!.state).toEqual({ agentId: 'a1' })
+  })
+
+  test('select focuses a present tab and is inert for an absent one', () => {
+    const state = run([
+      { type: 'openWorkspace', agents: [at('a1', 10), at('a2', 20)], cwd: '/ws', now: 30 },
+    ])
+    const second = state.tabs[1]!
+    const selected = run([
+      { type: 'openWorkspace', agents: [at('a1', 10), at('a2', 20)], cwd: '/ws', now: 30 },
+      { type: 'select', tabId: second.id },
+    ])
+    expect(selected.activeTabId).toBe(second.id)
+    const absent = run([
+      { type: 'openWorkspace', agents: [at('a1', 10)], cwd: '/ws', now: 30 },
+      { type: 'select', tabId: 'nope' },
+    ])
+    expect(absent.activeTabId).toBe(absent.tabs[0]!.id)
+  })
+
+  test('closing a non-active tab leaves the focus untouched', () => {
+    const state = run([
+      { type: 'openWorkspace', agents: [at('a1', 10), at('a2', 20)], cwd: '/ws', now: 30 },
+    ])
+    const second = state.tabs[1]!
+    const closed = reduceTabs(state, { type: 'close', tabId: second.id })
+    expect(closed.tabs).toHaveLength(2)
+    expect(closed.activeTabId).toBe(state.activeTabId)
+  })
+
+  test('closing the focused tab focuses the right-hand neighbor', () => {
+    const state = run([
+      { type: 'openWorkspace', agents: [at('a1', 10), at('a2', 20)], cwd: '/ws', now: 30 },
+    ])
+    const active = state.tabs[0]! // a2 (newest)
+    const after = reduceTabs(state, { type: 'close', tabId: active.id })
+    expect(after.activeTabId).toBe(state.tabs[1]!.id)
+  })
+
+  test('closing the focused last tab falls back to the left-hand neighbor', () => {
+    const opened = run([
+      { type: 'openWorkspace', agents: [at('a1', 10), at('a2', 20)], cwd: '/ws', now: 30 },
+    ])
+    const last = opened.tabs.at(-1)!
+    const state = run([
+      { type: 'openWorkspace', agents: [at('a1', 10), at('a2', 20)], cwd: '/ws', now: 30 },
+      { type: 'select', tabId: last.id },
+    ])
+    const after = reduceTabs(state, { type: 'close', tabId: last.id })
+    expect(after.activeTabId).toBe(state.tabs[state.tabs.length - 2]!.id)
+  })
+
+  test('closing the last remaining tab leaves a sane empty/new-task state', () => {
+    const state = run([{ type: 'openDraft', cwd: '/ws', now: 10 }])
+    const after = reduceTabs(state, { type: 'close', tabId: state.tabs[0]!.id })
+    expect(after.tabs).toEqual([])
+    expect(after.activeTabId).toBe(null)
+    expect(selectActiveAgentId(after)).toBe(null)
+  })
+
+  test('closeOthers keeps only the survivor and focuses it', () => {
+    const state = run([
+      { type: 'openWorkspace', agents: [at('a1', 10), at('a2', 20)], cwd: '/ws', now: 30 },
+    ])
+    const survivor = state.tabs[1]!
+    const after = reduceTabs(state, { type: 'closeOthers', tabId: survivor.id })
+    expect(after.tabs).toHaveLength(1)
+    expect(after.tabs[0]!.id).toBe(survivor.id)
+    expect(after.activeTabId).toBe(survivor.id)
+  })
+
+  test('closeOthers is inert for a single tab or an unknown survivor', () => {
+    const one = run([{ type: 'openDraft', cwd: '/ws', now: 1 }])
+    expect(reduceTabs(one, { type: 'closeOthers', tabId: one.tabs[0]!.id })).toBe(one)
+    const multi = run([
+      { type: 'openWorkspace', agents: [at('a1', 10), at('a2', 20)], cwd: '/ws', now: 30 },
+    ])
+    expect(reduceTabs(multi, { type: 'closeOthers', tabId: 'nope' })).toBe(multi)
+  })
+
+  test('hasAgentTab reports whether an agent already owns a tab', () => {
+    const state = run([{ type: 'openAgent', agentId: 'a1', createdAt: 5 }])
+    expect(hasAgentTab(state, 'a1')).toBe(true)
+    expect(hasAgentTab(state, 'a2')).toBe(false)
+  })
+
+  test('ids are deterministic and unique across mixed operations', () => {
+    const state = run([
+      { type: 'openWorkspace', agents: [at('a1', 10)], cwd: '/ws', now: 20 },
+      { type: 'openDraft', cwd: '/ws', now: 30 },
+      { type: 'openAgent', agentId: 'b1', createdAt: 40 },
+    ])
+    // openWorkspace: [agent(a1), draft], then another draft, then an agent.
+    expect(state.tabs.map((tab) => tab.id)).toEqual(['t0', 't1', 't2', 't3'])
+    expect(state.tabs.map((tab) => tab.target)).toEqual(['agent', 'draft', 'draft', 'agent'])
+  })
+
+  test('selectTabs and selectTab project the ordered list and single lookups', () => {
+    const state = run([{ type: 'openWorkspace', agents: [at('a1', 10)], cwd: '/ws', now: 20 }])
+    expect(selectTabs(state)).toHaveLength(2)
+    expect(selectTab(state, state.tabs[0]!.id)).toBe(state.tabs[0])
+    expect(selectTab(state, 'missing')).toBe(null)
+  })
+})

--- a/tabs/tabs.test.ts
+++ b/tabs/tabs.test.ts
@@ -86,6 +86,33 @@ describe('workspace tabs', () => {
     expect(new Set(state.tabs.map((tab) => tab.id)).size).toBe(2)
   })
 
+  test('setDraftWorktree toggles a draft tab worktree choice in place', () => {
+    const state = run([
+      { type: 'openDraft', cwd: '/ws', now: 10 },
+      { type: 'setDraftWorktree', tabId: 't0', worktree: 'worktree' },
+    ])
+    expect(state.tabs[0]!.target).toBe('draft')
+    expect(state.tabs[0]!.state).toEqual({ cwd: '/ws', worktree: 'worktree' })
+    // Focus is untouched, and re-setting the same value is inert.
+    expect(state.activeTabId).toBe('t0')
+    const same = run([
+      { type: 'openDraft', cwd: '/ws', now: 10 },
+      { type: 'setDraftWorktree', tabId: 't0', worktree: 'worktree' },
+      { type: 'setDraftWorktree', tabId: 't0', worktree: 'worktree' },
+    ])
+    expect(same.tabs[0]!.state).toEqual({ cwd: '/ws', worktree: 'worktree' })
+  })
+
+  test('setDraftWorktree is ignored for an unknown or non-draft tab', () => {
+    const state = run([
+      { type: 'openAgent', agentId: 'a1', createdAt: 1 },
+      { type: 'setDraftWorktree', tabId: 't0', worktree: 'worktree' },
+      { type: 'setDraftWorktree', tabId: 'nope', worktree: 'worktree' },
+    ])
+    expect(state.tabs[0]!.target).toBe('agent')
+    expect(state.tabs[0]!.state).toEqual({ agentId: 'a1' })
+  })
+
   test('openAgent focuses an existing agent tab instead of duplicating it', () => {
     const state = run([
       { type: 'openWorkspace', agents: [at('a1', 100), at('a2', 200)], cwd: '/ws', now: 300 },

--- a/tabs/tabs.ts
+++ b/tabs/tabs.ts
@@ -70,6 +70,8 @@ export type TabsEvent =
   | { type: 'openDraft'; cwd: string; now: number }
   /** A draft tab's first send created an agent: flip it to an agent tab. */
   | { type: 'draftSent'; tabId: string; agentId: string; createdAt: number }
+  /** Toggle a draft tab's worktree choice (local directory vs new worktree). */
+  | { type: 'setDraftWorktree'; tabId: string; worktree: 'local' | 'worktree' }
   /** Focus a tab. */
   | { type: 'select'; tabId: string }
   /** Close one tab; the focused-tab neighbor rule applies to avoid dead focus. */
@@ -158,6 +160,16 @@ export function reduceTabs(state: TabsState, event: TabsEvent): TabsState {
     case 'select': {
       const present = state.tabs.some((tab) => tab.id === event.tabId)
       return present && state.activeTabId !== event.tabId ? { ...state, activeTabId: event.tabId } : state
+    }
+
+    case 'setDraftWorktree': {
+      const tab = state.tabs.find((candidate) => candidate.id === event.tabId)
+      if (!tab || tab.target !== 'draft' || tab.state.worktree === event.worktree) return state
+      const tabs = state.tabs.map((candidate) => {
+        if (candidate.id !== event.tabId || candidate.target !== 'draft') return candidate
+        return { ...candidate, state: { ...candidate.state, worktree: event.worktree } }
+      })
+      return { tabs, activeTabId: state.activeTabId, seq: state.seq }
     }
 
     case 'close': {

--- a/tabs/tabs.ts
+++ b/tabs/tabs.ts
@@ -11,8 +11,8 @@
  * later stages (setup, panes) can extend it without reshaping the reducer.
  */
 
-/** A tab's kind. Read-only review targets and subagent/provider tabs are out
- *  of scope here; `setup` is anticipated by #47/#48 and holds no logic now. */
+/** A tab's kind. Read-only review targets are out of scope here; `setup` is a
+ *  worktree bootstrapping progress tab (#47). */
 export type TabTarget = 'draft' | 'agent' | 'setup'
 
 /** A draft tab's held folder picks: where a new agent would be created. */
@@ -26,10 +26,12 @@ export interface AgentTabState {
   agentId: string
 }
 
-/** A setup tab (anticipated for #47): keyed by workspace, mirrors the daemon's
- *  workspace_setup progress feed. */
+/** A setup tab (#47): a worktree bootstrapping, keyed by workspace, streaming
+ *  the daemon's workspace_setup progress; `agentId` is the agent the worktree
+ *  created, the conversation this tab hands off to on success. */
 export interface SetupTabState {
   workspaceId: string
+  agentId: string
 }
 
 export type TabState = DraftTabState | AgentTabState | SetupTabState
@@ -68,6 +70,8 @@ export type TabsEvent =
   | { type: 'openAgent'; agentId: string; createdAt: number }
   /** Append a fresh draft tab. */
   | { type: 'openDraft'; cwd: string; now: number }
+  /** Open (and focus) a setup tab for a worktree being bootstrapped. */
+  | { type: 'openSetup'; workspaceId: string; agentId: string; createdAt: number }
   /** A draft tab's first send created an agent: flip it to an agent tab. */
   | { type: 'draftSent'; tabId: string; agentId: string; createdAt: number }
   /** Toggle a draft tab's worktree choice (local directory vs new worktree). */
@@ -98,6 +102,11 @@ function appendDraft(state: TabsState, cwd: string, now: number): TabsState {
   const id = `t${state.seq}`
   const tab: TabDescriptor = { id, target: 'draft', createdAt: now, state: { cwd, worktree: 'local' } }
   return { tabs: [...state.tabs, tab], activeTabId: state.activeTabId, seq: state.seq + 1 }
+}
+
+/** True when `state` describes a setup tab for `workspaceId`. */
+function isSetupTab(tab: TabDescriptor, workspaceId: string): boolean {
+  return tab.target === 'setup' && tab.state.workspaceId === workspaceId
 }
 
 /**
@@ -140,6 +149,22 @@ export function reduceTabs(state: TabsState, event: TabsEvent): TabsState {
     case 'openDraft': {
       const next = appendDraft(state, event.cwd, event.now)
       return { ...next, activeTabId: next.tabs.at(-1)!.id }
+    }
+
+    case 'openSetup': {
+      // One setup tab per workspace being bootstrapped: a repeat open just
+      // focuses the existing one. It opens onto the agent the worktree created,
+      // which the setup hands off to on success.
+      const existing = state.tabs.find((candidate) => isSetupTab(candidate, event.workspaceId))
+      if (existing) return { ...state, activeTabId: existing.id }
+      const id = `t${state.seq}`
+      const tab: TabDescriptor = {
+        id,
+        target: 'setup',
+        createdAt: event.createdAt,
+        state: { workspaceId: event.workspaceId, agentId: event.agentId },
+      }
+      return { tabs: [...state.tabs, tab], activeTabId: id, seq: state.seq + 1 }
     }
 
     case 'draftSent': {
@@ -212,6 +237,12 @@ export function selectActiveAgentId(state: TabsState): string | null {
 export function selectActiveDraft(state: TabsState): DraftTabState | null {
   const tab = selectActiveTab(state)
   return tab && tab.target === 'draft' ? tab.state : null
+}
+
+/** The active tab, narrowed to a setup tab's state when it is one. */
+export function selectActiveSetup(state: TabsState): SetupTabState | null {
+  const tab = selectActiveTab(state)
+  return tab && tab.target === 'setup' ? tab.state : null
 }
 
 /** Whether `agentId` already has an open agent tab. */

--- a/tabs/tabs.ts
+++ b/tabs/tabs.ts
@@ -1,0 +1,208 @@
+/**
+ * Workspace tab strip state.
+ *
+ * Opening a workspace lands on a tab strip instead of a single fixed view:
+ * several agents from one workspace sit side by side as agent tabs, a draft
+ * tab holds the composer and creates the agent only on first send. The
+ * reducer is the whole decision — add, close, close-others, switch focus —
+ * and the hook/component only translates app gestures and daemon results into
+ * TabsEvents. Descriptors follow Paseo's own upstream shape (id, target,
+ * createdAt, state) with the target union ahead of the current two targets so
+ * later stages (setup, panes) can extend it without reshaping the reducer.
+ */
+
+/** A tab's kind. Read-only review targets and subagent/provider tabs are out
+ *  of scope here; `setup` is anticipated by #47/#48 and holds no logic now. */
+export type TabTarget = 'draft' | 'agent' | 'setup'
+
+/** A draft tab's held folder picks: where a new agent would be created. */
+export interface DraftTabState {
+  cwd: string
+  worktree: 'local' | 'worktree'
+}
+
+/** An agent tab: its conversation's owning agent. */
+export interface AgentTabState {
+  agentId: string
+}
+
+/** A setup tab (anticipated for #47): keyed by workspace, mirrors the daemon's
+ *  workspace_setup progress feed. */
+export interface SetupTabState {
+  workspaceId: string
+}
+
+export type TabState = DraftTabState | AgentTabState | SetupTabState
+
+export interface TabDescriptor {
+  /** The tab's unique strip identity; not the same as a target's id. */
+  id: string
+  target: TabTarget
+  createdAt: number
+  state: TabState
+}
+
+export interface TabsState {
+  /** Ordered left-to-right tabs; empty means the directory-level new task. */
+  tabs: TabDescriptor[]
+  /** The focused tab; null when there are no tabs (directory new-task state). */
+  activeTabId: string | null
+  /** Monotonic source of unique tab ids, so ids are deterministic and stable. */
+  seq: number
+}
+
+export const initialTabs: TabsState = { tabs: [], activeTabId: null, seq: 0 }
+
+/** The bare agent shape the reducer needs to build agent tabs from a workspace. */
+export interface WorkspaceAgentInput {
+  id: string
+  createdAt: number
+}
+
+export type TabsEvent =
+  /** New Task / directory-level reset: drop every tab. */
+  | { type: 'reset' }
+  /** Open a workspace: one agent tab per input (deduped), then a draft tab. */
+  | { type: 'openWorkspace'; agents: WorkspaceAgentInput[]; cwd: string; now: number }
+  /** Open/move focus to an agent, creating its tab when absent. */
+  | { type: 'openAgent'; agentId: string; createdAt: number }
+  /** Append a fresh draft tab. */
+  | { type: 'openDraft'; cwd: string; now: number }
+  /** A draft tab's first send created an agent: flip it to an agent tab. */
+  | { type: 'draftSent'; tabId: string; agentId: string; createdAt: number }
+  /** Focus a tab. */
+  | { type: 'select'; tabId: string }
+  /** Close one tab; the focused-tab neighbor rule applies to avoid dead focus. */
+  | { type: 'close'; tabId: string }
+  /** Close every tab but one, focusing the survivor. */
+  | { type: 'closeOthers'; tabId: string }
+
+/** True when `state` describes an agent tab for `agentId`. */
+function isAgentTab(tab: TabDescriptor, agentId: string): boolean {
+  return tab.target === 'agent' && tab.state.agentId === agentId
+}
+
+/** Appends an agent tab; re-using an existing one for the same agent returns it unchanged. */
+function upsertAgentTab(state: TabsState, agentId: string, createdAt: number): TabsState {
+  const existing = state.tabs.find((tab) => isAgentTab(tab, agentId))
+  if (existing) return state
+  const id = `t${state.seq}`
+  const tab: TabDescriptor = { id, target: 'agent', createdAt, state: { agentId } }
+  return { tabs: [...state.tabs, tab], activeTabId: state.activeTabId, seq: state.seq + 1 }
+}
+
+/** Appends a draft tab and returns it (used by both openWorkspace and openDraft). */
+function appendDraft(state: TabsState, cwd: string, now: number): TabsState {
+  const id = `t${state.seq}`
+  const tab: TabDescriptor = { id, target: 'draft', createdAt: now, state: { cwd, worktree: 'local' } }
+  return { tabs: [...state.tabs, tab], activeTabId: state.activeTabId, seq: state.seq + 1 }
+}
+
+/**
+ * Closing a tab focuses a deterministic neighbor, computed against the tabs
+ * that remain: the tab just to the right of the closed slot when one exists
+ * (the strip reads left-to-right), else the one to its left, else nothing —
+ * the clean empty/new-task state.
+ */
+function neighborOnClose(remaining: TabDescriptor[], closedIndex: number): string | null {
+  if (closedIndex < remaining.length) return remaining[closedIndex]!.id
+  if (closedIndex - 1 >= 0) return remaining[closedIndex - 1]!.id
+  return null
+}
+
+export function reduceTabs(state: TabsState, event: TabsEvent): TabsState {
+  switch (event.type) {
+    case 'reset':
+      return initialTabs
+
+    case 'openWorkspace': {
+      // Newest agent tab first, so the workspace opens onto its most recent
+      // work; existing agent tabs are reused in place (no duplication), and a
+      // trailing draft tab always offers a way to start something new.
+      const agents = [...event.agents].sort((a, b) => b.createdAt - a.createdAt)
+      let next = state
+      for (const agent of agents) next = upsertAgentTab(next, agent.id, agent.createdAt)
+      if (next.tabs.some((tab) => tab.target === 'draft')) {
+        return { ...next, activeTabId: next.tabs[0]?.id ?? next.activeTabId }
+      }
+      next = appendDraft(next, event.cwd, event.now)
+      return { ...next, activeTabId: next.tabs[0]?.id ?? next.activeTabId }
+    }
+
+    case 'openAgent': {
+      const next = upsertAgentTab(state, event.agentId, event.createdAt)
+      const tab = next.tabs.find((candidate) => isAgentTab(candidate, event.agentId))
+      return { ...next, activeTabId: tab?.id ?? next.activeTabId }
+    }
+
+    case 'openDraft': {
+      const next = appendDraft(state, event.cwd, event.now)
+      return { ...next, activeTabId: next.tabs.at(-1)!.id }
+    }
+
+    case 'draftSent': {
+      const tab = state.tabs.find((candidate) => candidate.id === event.tabId)
+      if (!tab || tab.target !== 'draft') return state
+      const flipped: TabDescriptor = {
+        ...tab,
+        target: 'agent',
+        state: { agentId: event.agentId },
+      }
+      return {
+        tabs: state.tabs.map((candidate) => (candidate.id === event.tabId ? flipped : candidate)),
+        activeTabId: event.tabId,
+        seq: state.seq,
+      }
+    }
+
+    case 'select': {
+      const present = state.tabs.some((tab) => tab.id === event.tabId)
+      return present && state.activeTabId !== event.tabId ? { ...state, activeTabId: event.tabId } : state
+    }
+
+    case 'close': {
+      const closedIndex = state.tabs.findIndex((tab) => tab.id === event.tabId)
+      if (closedIndex < 0) return state
+      const tabs = state.tabs.filter((tab) => tab.id !== event.tabId)
+      const active = state.activeTabId === event.tabId ? neighborOnClose(tabs, closedIndex) : state.activeTabId
+      return { tabs, activeTabId: active, seq: state.seq }
+    }
+
+    case 'closeOthers': {
+      const survivor = state.tabs.find((tab) => tab.id === event.tabId)
+      if (!survivor || state.tabs.length === 1) return state
+      return { tabs: [survivor], activeTabId: survivor.id, seq: state.seq }
+    }
+  }
+}
+
+// ---- selectors --------------------------------------------------------------
+
+export function selectTabs(state: TabsState): TabDescriptor[] {
+  return state.tabs
+}
+
+export function selectTab(state: TabsState, tabId: string): TabDescriptor | null {
+  return state.tabs.find((tab) => tab.id === tabId) ?? null
+}
+
+export function selectActiveTab(state: TabsState): TabDescriptor | null {
+  return state.tabs.find((tab) => tab.id === state.activeTabId) ?? null
+}
+
+/** The active agent tab's agent id, or null for a draft/no active tab. */
+export function selectActiveAgentId(state: TabsState): string | null {
+  const tab = selectActiveTab(state)
+  return tab && tab.target === 'agent' ? tab.state.agentId : null
+}
+
+/** The active tab, narrowed to a draft tab's state when it is a draft. */
+export function selectActiveDraft(state: TabsState): DraftTabState | null {
+  const tab = selectActiveTab(state)
+  return tab && tab.target === 'draft' ? tab.state : null
+}
+
+/** Whether `agentId` already has an open agent tab. */
+export function hasAgentTab(state: TabsState, agentId: string): boolean {
+  return state.tabs.some((tab) => isAgentTab(tab, agentId))
+}


### PR DESCRIPTION
Implements the workspace-layer spec #33 on a single branch, ticket by ticket.

Closes #33
Closes #41
Closes #42
Closes #43
Closes #44
Closes #45
Closes #46
Closes #47
Closes #48

## Ticket graph

Already unblocked and landed in earlier PRs: #39 (workspace directory), #40 (persisted app-state store).

| Wave | Tickets |
|---|---|
| 1 | #41 collapsed-project aggregate pill, #42 row meta line |
| 2 | #43 row menu, #44 display preferences |
| 3 | #46 tabs, #45 jump shortcuts |
| 4 | #47 setup tab, #48 panes |

Each ticket is implemented in its own worktree/branch and merged here by a merger pass. Draft until all tickets land and code review passes.